### PR TITLE
Update samples to xcode7

### DIFF
--- a/Freewheel/BasicFreewheelPlayer/objc/BasicFreewheelPlayer/Base.lproj/LaunchScreen.xib
+++ b/Freewheel/BasicFreewheelPlayer/objc/BasicFreewheelPlayer/Base.lproj/LaunchScreen.xib
@@ -12,7 +12,7 @@
             <rect key="frame" x="0.0" y="0.0" width="480" height="480"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2014 BrightCove. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2015 BrightCove. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
                     <rect key="frame" x="20" y="439" width="441" height="21"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>

--- a/IMA+Widevine/BasicIMAWidevinePlayer/objc/BasicIMAWidevinePlayer/Base.lproj/LaunchScreen.xib
+++ b/IMA+Widevine/BasicIMAWidevinePlayer/objc/BasicIMAWidevinePlayer/Base.lproj/LaunchScreen.xib
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6214" systemVersion="14A314h" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6207"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
     </dependencies>
     <objects>
@@ -11,7 +12,7 @@
             <rect key="frame" x="0.0" y="0.0" width="480" height="480"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2014 BrightCove. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2015 BrightCove. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
                     <rect key="frame" x="20" y="439" width="441" height="21"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>

--- a/IMA/BasicIMAPlayer/objc/BasicIMAPlayer/Base.lproj/LaunchScreen.xib
+++ b/IMA/BasicIMAPlayer/objc/BasicIMAPlayer/Base.lproj/LaunchScreen.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6250" systemVersion="14A389" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6244"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
     </dependencies>
     <objects>
@@ -12,7 +12,7 @@
             <rect key="frame" x="0.0" y="0.0" width="480" height="480"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2014 BrightCove. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2015 BrightCove. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
                     <rect key="frame" x="20" y="439" width="441" height="21"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>

--- a/OUX/BasicOUXPlayer/objc/BasicOUXPlayer/Base.lproj/LaunchScreen.xib
+++ b/OUX/BasicOUXPlayer/objc/BasicOUXPlayer/Base.lproj/LaunchScreen.xib
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6214" systemVersion="14A314h" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6207"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
     </dependencies>
     <objects>

--- a/OUX/BasicOUXPlayer/objc/BasicOUXPlayer/Base.lproj/LaunchScreen.xib
+++ b/OUX/BasicOUXPlayer/objc/BasicOUXPlayer/Base.lproj/LaunchScreen.xib
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6214" systemVersion="14A314h" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6207"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
     </dependencies>
     <objects>

--- a/Omniture/BasicOmniturePlayer/objc/BasicOmniturePlayer/Base.lproj/LaunchScreen.xib
+++ b/Omniture/BasicOmniturePlayer/objc/BasicOmniturePlayer/Base.lproj/LaunchScreen.xib
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6214" systemVersion="14A314h" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6207"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
     </dependencies>
     <objects>
@@ -11,7 +12,7 @@
             <rect key="frame" x="0.0" y="0.0" width="480" height="480"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2014 Brightcove Inc. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2015 Brightcove Inc. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
                     <rect key="frame" x="20" y="439" width="441" height="21"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>

--- a/Player/CustomControls/objc/CustomControls.xcodeproj/project.pbxproj
+++ b/Player/CustomControls/objc/CustomControls.xcodeproj/project.pbxproj
@@ -13,21 +13,10 @@
 		49E642211A0280DD00D284AC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 49E6421F1A0280DD00D284AC /* Main.storyboard */; };
 		49E642231A0280DD00D284AC /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 49E642221A0280DD00D284AC /* Images.xcassets */; };
 		49E642261A0280DD00D284AC /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 49E642241A0280DD00D284AC /* LaunchScreen.xib */; };
-		49E642321A0280DD00D284AC /* CustomControlsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 49E642311A0280DD00D284AC /* CustomControlsTests.m */; };
 		49E6423E1A02932F00D284AC /* ControlsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 49E6423C1A02932F00D284AC /* ControlsViewController.m */; };
 		49E6423F1A02932F00D284AC /* ControlsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 49E6423D1A02932F00D284AC /* ControlsViewController.xib */; };
 		B03A493930F97BCD8D699D6C /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9E0DB68626830925D43DB64A /* libPods.a */; };
 /* End PBXBuildFile section */
-
-/* Begin PBXContainerItemProxy section */
-		49E6422C1A0280DD00D284AC /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 49E6420A1A0280DD00D284AC /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 49E642111A0280DD00D284AC;
-			remoteInfo = CustomControls;
-		};
-/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		172C0D93AAC4553DCF7413DB /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
@@ -41,7 +30,6 @@
 		49E642201A0280DD00D284AC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		49E642221A0280DD00D284AC /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		49E642251A0280DD00D284AC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
-		49E6422B1A0280DD00D284AC /* CustomControlsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CustomControlsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		49E642301A0280DD00D284AC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		49E642311A0280DD00D284AC /* CustomControlsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CustomControlsTests.m; sourceTree = "<group>"; };
 		49E6423B1A02932F00D284AC /* ControlsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ControlsViewController.h; sourceTree = "<group>"; };
@@ -57,13 +45,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				B03A493930F97BCD8D699D6C /* libPods.a in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		49E642281A0280DD00D284AC /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -93,7 +74,6 @@
 			isa = PBXGroup;
 			children = (
 				49E642121A0280DD00D284AC /* CustomControls.app */,
-				49E6422B1A0280DD00D284AC /* CustomControlsTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -173,24 +153,6 @@
 			productReference = 49E642121A0280DD00D284AC /* CustomControls.app */;
 			productType = "com.apple.product-type.application";
 		};
-		49E6422A1A0280DD00D284AC /* CustomControlsTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 49E642381A0280DD00D284AC /* Build configuration list for PBXNativeTarget "CustomControlsTests" */;
-			buildPhases = (
-				49E642271A0280DD00D284AC /* Sources */,
-				49E642281A0280DD00D284AC /* Frameworks */,
-				49E642291A0280DD00D284AC /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				49E6422D1A0280DD00D284AC /* PBXTargetDependency */,
-			);
-			name = CustomControlsTests;
-			productName = CustomControlsTests;
-			productReference = 49E6422B1A0280DD00D284AC /* CustomControlsTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -208,10 +170,6 @@
 							};
 						};
 					};
-					49E6422A1A0280DD00D284AC = {
-						CreatedOnToolsVersion = 6.1;
-						TestTargetID = 49E642111A0280DD00D284AC;
-					};
 				};
 			};
 			buildConfigurationList = 49E6420D1A0280DD00D284AC /* Build configuration list for PBXProject "CustomControls" */;
@@ -228,7 +186,6 @@
 			projectRoot = "";
 			targets = (
 				49E642111A0280DD00D284AC /* CustomControls */,
-				49E6422A1A0280DD00D284AC /* CustomControlsTests */,
 			);
 		};
 /* End PBXProject section */
@@ -242,13 +199,6 @@
 				49E642261A0280DD00D284AC /* LaunchScreen.xib in Resources */,
 				49E6423F1A02932F00D284AC /* ControlsViewController.xib in Resources */,
 				49E642231A0280DD00D284AC /* Images.xcassets in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		49E642291A0280DD00D284AC /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -299,23 +249,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		49E642271A0280DD00D284AC /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				49E642321A0280DD00D284AC /* CustomControlsTests.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		49E6422D1A0280DD00D284AC /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 49E642111A0280DD00D284AC /* CustomControls */;
-			targetProxy = 49E6422C1A0280DD00D284AC /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		49E6421F1A0280DD00D284AC /* Main.storyboard */ = {
@@ -356,7 +290,9 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				ENABLE_BITCODE = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -398,8 +334,10 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
+				ENABLE_BITCODE = NO;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
@@ -421,8 +359,9 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = CustomControls/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.brightcove.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -433,43 +372,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = CustomControls/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.brightcove.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-			};
-			name = Release;
-		};
-		49E642391A0280DD00D284AC /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				INFOPLIST_FILE = CustomControlsTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CustomControls.app/CustomControls";
-			};
-			name = Debug;
-		};
-		49E6423A1A0280DD00D284AC /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
-				INFOPLIST_FILE = CustomControlsTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CustomControls.app/CustomControls";
 			};
 			name = Release;
 		};
@@ -490,15 +396,6 @@
 			buildConfigurations = (
 				49E642361A0280DD00D284AC /* Debug */,
 				49E642371A0280DD00D284AC /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		49E642381A0280DD00D284AC /* Build configuration list for PBXNativeTarget "CustomControlsTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				49E642391A0280DD00D284AC /* Debug */,
-				49E6423A1A0280DD00D284AC /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Player/CustomControls/objc/CustomControls/Base.lproj/LaunchScreen.xib
+++ b/Player/CustomControls/objc/CustomControls/Base.lproj/LaunchScreen.xib
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6214" systemVersion="14A314h" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6207"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
     </dependencies>
     <objects>
@@ -11,7 +12,7 @@
             <rect key="frame" x="0.0" y="0.0" width="480" height="480"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2014 Brightcove. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2015 Brightcove. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
                     <rect key="frame" x="20" y="439" width="441" height="21"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>

--- a/Player/CustomControls/objc/CustomControls/Info.plist
+++ b/Player/CustomControls/objc/CustomControls/Info.plist
@@ -2,12 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.brightcove.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Player/CustomControls/objc/Podfile.lock
+++ b/Player/CustomControls/objc/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - Brightcove-Player-SDK (4.3.3)
+  - Brightcove-Player-SDK (4.4.1)
 
 DEPENDENCIES:
   - Brightcove-Player-SDK
 
 SPEC CHECKSUMS:
-  Brightcove-Player-SDK: a66b890fe7b3f75955c6ff536ebaba51d55952ee
+  Brightcove-Player-SDK: 8ed4f3795381b86c2b8f568cd33bee9b6364a238
 
-COCOAPODS: 0.37.2
+COCOAPODS: 0.38.2

--- a/Player/DVRLive/objc/DVRLive.xcodeproj/project.pbxproj
+++ b/Player/DVRLive/objc/DVRLive.xcodeproj/project.pbxproj
@@ -13,19 +13,8 @@
 		989F28CE1AA50335000DAB8B /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 989F28CC1AA50335000DAB8B /* Main.storyboard */; };
 		989F28D01AA50335000DAB8B /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 989F28CF1AA50335000DAB8B /* Images.xcassets */; };
 		989F28D31AA50335000DAB8B /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 989F28D11AA50335000DAB8B /* LaunchScreen.xib */; };
-		989F28DF1AA50335000DAB8B /* DVRLiveTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 989F28DE1AA50335000DAB8B /* DVRLiveTests.m */; };
 		F7CBF6580F918FC6DE7EEC63 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 690D573FFD94CE1A5A8D59D4 /* libPods.a */; };
 /* End PBXBuildFile section */
-
-/* Begin PBXContainerItemProxy section */
-		989F28D91AA50335000DAB8B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 989F28B71AA50335000DAB8B /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 989F28BE1AA50335000DAB8B;
-			remoteInfo = DVRLive;
-		};
-/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		690D573FFD94CE1A5A8D59D4 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -41,7 +30,6 @@
 		989F28CD1AA50335000DAB8B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		989F28CF1AA50335000DAB8B /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		989F28D21AA50335000DAB8B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
-		989F28D81AA50335000DAB8B /* DVRLiveTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DVRLiveTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		989F28DD1AA50335000DAB8B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		989F28DE1AA50335000DAB8B /* DVRLiveTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DVRLiveTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -52,13 +40,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				F7CBF6580F918FC6DE7EEC63 /* libPods.a in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		989F28D51AA50335000DAB8B /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -97,7 +78,6 @@
 			isa = PBXGroup;
 			children = (
 				989F28BF1AA50335000DAB8B /* DVRLive.app */,
-				989F28D81AA50335000DAB8B /* DVRLiveTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -165,24 +145,6 @@
 			productReference = 989F28BF1AA50335000DAB8B /* DVRLive.app */;
 			productType = "com.apple.product-type.application";
 		};
-		989F28D71AA50335000DAB8B /* DVRLiveTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 989F28E51AA50335000DAB8B /* Build configuration list for PBXNativeTarget "DVRLiveTests" */;
-			buildPhases = (
-				989F28D41AA50335000DAB8B /* Sources */,
-				989F28D51AA50335000DAB8B /* Frameworks */,
-				989F28D61AA50335000DAB8B /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				989F28DA1AA50335000DAB8B /* PBXTargetDependency */,
-			);
-			name = DVRLiveTests;
-			productName = DVRLiveTests;
-			productReference = 989F28D81AA50335000DAB8B /* DVRLiveTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -194,10 +156,6 @@
 				TargetAttributes = {
 					989F28BE1AA50335000DAB8B = {
 						CreatedOnToolsVersion = 6.1.1;
-					};
-					989F28D71AA50335000DAB8B = {
-						CreatedOnToolsVersion = 6.1.1;
-						TestTargetID = 989F28BE1AA50335000DAB8B;
 					};
 				};
 			};
@@ -215,7 +173,6 @@
 			projectRoot = "";
 			targets = (
 				989F28BE1AA50335000DAB8B /* DVRLive */,
-				989F28D71AA50335000DAB8B /* DVRLiveTests */,
 			);
 		};
 /* End PBXProject section */
@@ -228,13 +185,6 @@
 				989F28CE1AA50335000DAB8B /* Main.storyboard in Resources */,
 				989F28D31AA50335000DAB8B /* LaunchScreen.xib in Resources */,
 				989F28D01AA50335000DAB8B /* Images.xcassets in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		989F28D61AA50335000DAB8B /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -284,23 +234,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		989F28D41AA50335000DAB8B /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				989F28DF1AA50335000DAB8B /* DVRLiveTests.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		989F28DA1AA50335000DAB8B /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 989F28BE1AA50335000DAB8B /* DVRLive */;
-			targetProxy = 989F28D91AA50335000DAB8B /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		989F28CC1AA50335000DAB8B /* Main.storyboard */ = {
@@ -405,9 +339,13 @@
 			baseConfigurationReference = 8C8DA855232DCD35CD8DF924 /* Pods.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
 				INFOPLIST_FILE = DVRLive/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.brightcove.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -417,44 +355,14 @@
 			baseConfigurationReference = 6ABE3E428F126C192F462FA9 /* Pods.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
 				INFOPLIST_FILE = DVRLive/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.brightcove.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-			};
-			name = Release;
-		};
-		989F28E61AA50335000DAB8B /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				INFOPLIST_FILE = DVRLiveTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/DVRLive.app/DVRLive";
-			};
-			name = Debug;
-		};
-		989F28E71AA50335000DAB8B /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
-				INFOPLIST_FILE = DVRLiveTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/DVRLive.app/DVRLive";
 			};
 			name = Release;
 		};
@@ -475,15 +383,6 @@
 			buildConfigurations = (
 				989F28E31AA50335000DAB8B /* Debug */,
 				989F28E41AA50335000DAB8B /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		989F28E51AA50335000DAB8B /* Build configuration list for PBXNativeTarget "DVRLiveTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				989F28E61AA50335000DAB8B /* Debug */,
-				989F28E71AA50335000DAB8B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Player/DVRLive/objc/DVRLive/Base.lproj/LaunchScreen.xib
+++ b/Player/DVRLive/objc/DVRLive/Base.lproj/LaunchScreen.xib
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6214" systemVersion="14A314h" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6207"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
     </dependencies>
     <objects>

--- a/Player/DVRLive/objc/DVRLive/Info.plist
+++ b/Player/DVRLive/objc/DVRLive/Info.plist
@@ -2,12 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>Brightcove.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Player/DVRLive/objc/Podfile.lock
+++ b/Player/DVRLive/objc/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - Brightcove-Player-SDK (4.3.3)
+  - Brightcove-Player-SDK (4.4.1)
 
 DEPENDENCIES:
   - Brightcove-Player-SDK
 
 SPEC CHECKSUMS:
-  Brightcove-Player-SDK: a66b890fe7b3f75955c6ff536ebaba51d55952ee
+  Brightcove-Player-SDK: 8ed4f3795381b86c2b8f568cd33bee9b6364a238
 
-COCOAPODS: 0.37.2
+COCOAPODS: 0.38.2

--- a/Player/VideoCloudBasicPlayer/objc/Podfile.lock
+++ b/Player/VideoCloudBasicPlayer/objc/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - Brightcove-Player-SDK (4.3.3)
+  - Brightcove-Player-SDK (4.4.1)
 
 DEPENDENCIES:
   - Brightcove-Player-SDK
 
 SPEC CHECKSUMS:
-  Brightcove-Player-SDK: a66b890fe7b3f75955c6ff536ebaba51d55952ee
+  Brightcove-Player-SDK: 8ed4f3795381b86c2b8f568cd33bee9b6364a238
 
-COCOAPODS: 0.37.2
+COCOAPODS: 0.38.2

--- a/Player/VideoCloudBasicPlayer/objc/VideoCloudBasicPlayer.xcodeproj/project.pbxproj
+++ b/Player/VideoCloudBasicPlayer/objc/VideoCloudBasicPlayer.xcodeproj/project.pbxproj
@@ -14,18 +14,7 @@
 		4907B1DF19D9DACF002EA892 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4907B1DD19D9DACF002EA892 /* Main.storyboard */; };
 		4907B1E119D9DACF002EA892 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4907B1E019D9DACF002EA892 /* Images.xcassets */; };
 		4907B1E419D9DACF002EA892 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4907B1E219D9DACF002EA892 /* LaunchScreen.xib */; };
-		4907B1F019D9DACF002EA892 /* VideoCloudBasicPlayerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4907B1EF19D9DACF002EA892 /* VideoCloudBasicPlayerTests.m */; };
 /* End PBXBuildFile section */
-
-/* Begin PBXContainerItemProxy section */
-		4907B1EA19D9DACF002EA892 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4907B1C819D9DACF002EA892 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 4907B1CF19D9DACF002EA892;
-			remoteInfo = VideoCloudBasicPlayer;
-		};
-/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		3A11B0764363A7E03C737BEA /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
@@ -39,7 +28,6 @@
 		4907B1DE19D9DACF002EA892 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		4907B1E019D9DACF002EA892 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		4907B1E319D9DACF002EA892 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
-		4907B1E919D9DACF002EA892 /* VideoCloudBasicPlayerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VideoCloudBasicPlayerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4907B1EE19D9DACF002EA892 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4907B1EF19D9DACF002EA892 /* VideoCloudBasicPlayerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = VideoCloudBasicPlayerTests.m; sourceTree = "<group>"; };
 		4D8DFF7AB393BD837EAC1D3C /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
@@ -52,13 +40,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				13DDBDB4638911D1480158AC /* libPods.a in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		4907B1E619D9DACF002EA892 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -89,7 +70,6 @@
 			isa = PBXGroup;
 			children = (
 				4907B1D019D9DACF002EA892 /* VideoCloudBasicPlayer.app */,
-				4907B1E919D9DACF002EA892 /* VideoCloudBasicPlayerTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -165,24 +145,6 @@
 			productReference = 4907B1D019D9DACF002EA892 /* VideoCloudBasicPlayer.app */;
 			productType = "com.apple.product-type.application";
 		};
-		4907B1E819D9DACF002EA892 /* VideoCloudBasicPlayerTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 4907B1F619D9DACF002EA892 /* Build configuration list for PBXNativeTarget "VideoCloudBasicPlayerTests" */;
-			buildPhases = (
-				4907B1E519D9DACF002EA892 /* Sources */,
-				4907B1E619D9DACF002EA892 /* Frameworks */,
-				4907B1E719D9DACF002EA892 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				4907B1EB19D9DACF002EA892 /* PBXTargetDependency */,
-			);
-			name = VideoCloudBasicPlayerTests;
-			productName = VideoCloudBasicPlayerTests;
-			productReference = 4907B1E919D9DACF002EA892 /* VideoCloudBasicPlayerTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -200,10 +162,6 @@
 							};
 						};
 					};
-					4907B1E819D9DACF002EA892 = {
-						CreatedOnToolsVersion = 6.0.1;
-						TestTargetID = 4907B1CF19D9DACF002EA892;
-					};
 				};
 			};
 			buildConfigurationList = 4907B1CB19D9DACF002EA892 /* Build configuration list for PBXProject "VideoCloudBasicPlayer" */;
@@ -220,7 +178,6 @@
 			projectRoot = "";
 			targets = (
 				4907B1CF19D9DACF002EA892 /* VideoCloudBasicPlayer */,
-				4907B1E819D9DACF002EA892 /* VideoCloudBasicPlayerTests */,
 			);
 		};
 /* End PBXProject section */
@@ -233,13 +190,6 @@
 				4907B1DF19D9DACF002EA892 /* Main.storyboard in Resources */,
 				4907B1E419D9DACF002EA892 /* LaunchScreen.xib in Resources */,
 				4907B1E119D9DACF002EA892 /* Images.xcassets in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		4907B1E719D9DACF002EA892 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -289,23 +239,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		4907B1E519D9DACF002EA892 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				4907B1F019D9DACF002EA892 /* VideoCloudBasicPlayerTests.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		4907B1EB19D9DACF002EA892 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 4907B1CF19D9DACF002EA892 /* VideoCloudBasicPlayer */;
-			targetProxy = 4907B1EA19D9DACF002EA892 /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		4907B1DD19D9DACF002EA892 /* Main.storyboard */ = {
@@ -410,9 +344,12 @@
 			baseConfigurationReference = 3A11B0764363A7E03C737BEA /* Pods.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
 				INFOPLIST_FILE = VideoCloudBasicPlayer/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.brightcove.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -422,44 +359,13 @@
 			baseConfigurationReference = 4D8DFF7AB393BD837EAC1D3C /* Pods.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
 				INFOPLIST_FILE = VideoCloudBasicPlayer/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.brightcove.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-			};
-			name = Release;
-		};
-		4907B1F719D9DACF002EA892 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				INFOPLIST_FILE = VideoCloudBasicPlayerTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/VideoCloudBasicPlayer.app/VideoCloudBasicPlayer";
-			};
-			name = Debug;
-		};
-		4907B1F819D9DACF002EA892 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
-				INFOPLIST_FILE = VideoCloudBasicPlayerTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/VideoCloudBasicPlayer.app/VideoCloudBasicPlayer";
 			};
 			name = Release;
 		};
@@ -480,15 +386,6 @@
 			buildConfigurations = (
 				4907B1F419D9DACF002EA892 /* Debug */,
 				4907B1F519D9DACF002EA892 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		4907B1F619D9DACF002EA892 /* Build configuration list for PBXNativeTarget "VideoCloudBasicPlayerTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				4907B1F719D9DACF002EA892 /* Debug */,
-				4907B1F819D9DACF002EA892 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Player/VideoCloudBasicPlayer/objc/VideoCloudBasicPlayer/Base.lproj/LaunchScreen.xib
+++ b/Player/VideoCloudBasicPlayer/objc/VideoCloudBasicPlayer/Base.lproj/LaunchScreen.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6250" systemVersion="14A389" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6244"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
     </dependencies>
     <objects>
@@ -12,7 +12,7 @@
             <rect key="frame" x="0.0" y="0.0" width="480" height="480"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2014 Brightcove. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2015 Brightcove. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
                     <rect key="frame" x="20" y="439" width="441" height="21"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>

--- a/Player/VideoCloudBasicPlayer/objc/VideoCloudBasicPlayer/Info.plist
+++ b/Player/VideoCloudBasicPlayer/objc/VideoCloudBasicPlayer/Info.plist
@@ -2,12 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.brightcove.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Player/VideoCloudBasicPlayer/swift/Podfile.lock
+++ b/Player/VideoCloudBasicPlayer/swift/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - Brightcove-Player-SDK (4.3.3)
+  - Brightcove-Player-SDK (4.4.1)
 
 DEPENDENCIES:
   - Brightcove-Player-SDK
 
 SPEC CHECKSUMS:
-  Brightcove-Player-SDK: a66b890fe7b3f75955c6ff536ebaba51d55952ee
+  Brightcove-Player-SDK: 8ed4f3795381b86c2b8f568cd33bee9b6364a238
 
-COCOAPODS: 0.37.2
+COCOAPODS: 0.38.2

--- a/Player/VideoCloudBasicPlayer/swift/VideoCloudBasicPlayer.xcodeproj/project.pbxproj
+++ b/Player/VideoCloudBasicPlayer/swift/VideoCloudBasicPlayer.xcodeproj/project.pbxproj
@@ -12,19 +12,8 @@
 		491576AA19D9F2B700B2E657 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 491576A819D9F2B700B2E657 /* Main.storyboard */; };
 		491576AC19D9F2B700B2E657 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 491576AB19D9F2B700B2E657 /* Images.xcassets */; };
 		491576AF19D9F2B700B2E657 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 491576AD19D9F2B700B2E657 /* LaunchScreen.xib */; };
-		491576BB19D9F2B700B2E657 /* VideoCloudBasicPlayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491576BA19D9F2B700B2E657 /* VideoCloudBasicPlayerTests.swift */; };
 		96C46085E540E3294C8C342D /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F729F41294113D50C0638071 /* libPods.a */; };
 /* End PBXBuildFile section */
-
-/* Begin PBXContainerItemProxy section */
-		491576B519D9F2B700B2E657 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4915769719D9F2B700B2E657 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 4915769E19D9F2B700B2E657;
-			remoteInfo = VideoCloudBasicPlayer;
-		};
-/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		4915769F19D9F2B700B2E657 /* VideoCloudBasicPlayer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VideoCloudBasicPlayer.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -34,7 +23,6 @@
 		491576A919D9F2B700B2E657 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		491576AB19D9F2B700B2E657 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		491576AE19D9F2B700B2E657 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
-		491576B419D9F2B700B2E657 /* VideoCloudBasicPlayerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VideoCloudBasicPlayerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		491576B919D9F2B700B2E657 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		491576BA19D9F2B700B2E657 /* VideoCloudBasicPlayerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCloudBasicPlayerTests.swift; sourceTree = "<group>"; };
 		491576C419D9FCB400B2E657 /* VideoCloudBasicPlayer-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "VideoCloudBasicPlayer-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -49,13 +37,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				96C46085E540E3294C8C342D /* libPods.a in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		491576B119D9F2B700B2E657 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -77,7 +58,6 @@
 			isa = PBXGroup;
 			children = (
 				4915769F19D9F2B700B2E657 /* VideoCloudBasicPlayer.app */,
-				491576B419D9F2B700B2E657 /* VideoCloudBasicPlayerTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -160,39 +140,18 @@
 			productReference = 4915769F19D9F2B700B2E657 /* VideoCloudBasicPlayer.app */;
 			productType = "com.apple.product-type.application";
 		};
-		491576B319D9F2B700B2E657 /* VideoCloudBasicPlayerTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 491576C119D9F2B700B2E657 /* Build configuration list for PBXNativeTarget "VideoCloudBasicPlayerTests" */;
-			buildPhases = (
-				491576B019D9F2B700B2E657 /* Sources */,
-				491576B119D9F2B700B2E657 /* Frameworks */,
-				491576B219D9F2B700B2E657 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				491576B619D9F2B700B2E657 /* PBXTargetDependency */,
-			);
-			name = VideoCloudBasicPlayerTests;
-			productName = VideoCloudBasicPlayerTests;
-			productReference = 491576B419D9F2B700B2E657 /* VideoCloudBasicPlayerTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		4915769719D9F2B700B2E657 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftMigration = 0700;
 				LastUpgradeCheck = 0600;
 				ORGANIZATIONNAME = Brightcove;
 				TargetAttributes = {
 					4915769E19D9F2B700B2E657 = {
 						CreatedOnToolsVersion = 6.0.1;
-					};
-					491576B319D9F2B700B2E657 = {
-						CreatedOnToolsVersion = 6.0.1;
-						TestTargetID = 4915769E19D9F2B700B2E657;
 					};
 				};
 			};
@@ -210,7 +169,6 @@
 			projectRoot = "";
 			targets = (
 				4915769E19D9F2B700B2E657 /* VideoCloudBasicPlayer */,
-				491576B319D9F2B700B2E657 /* VideoCloudBasicPlayerTests */,
 			);
 		};
 /* End PBXProject section */
@@ -223,13 +181,6 @@
 				491576AA19D9F2B700B2E657 /* Main.storyboard in Resources */,
 				491576AF19D9F2B700B2E657 /* LaunchScreen.xib in Resources */,
 				491576AC19D9F2B700B2E657 /* Images.xcassets in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		491576B219D9F2B700B2E657 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -278,23 +229,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		491576B019D9F2B700B2E657 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				491576BB19D9F2B700B2E657 /* VideoCloudBasicPlayerTests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		491576B619D9F2B700B2E657 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 4915769E19D9F2B700B2E657 /* VideoCloudBasicPlayer */;
-			targetProxy = 491576B519D9F2B700B2E657 /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		491576A819D9F2B700B2E657 /* Main.storyboard */ = {
@@ -335,7 +270,9 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				ENABLE_BITCODE = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -353,6 +290,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.brightcove.$(PRODUCT_NAME:rfc1034identifier";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -378,8 +316,10 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
+				ENABLE_BITCODE = NO;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
@@ -389,6 +329,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.brightcove.$(PRODUCT_NAME:rfc1034identifier";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -401,7 +342,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = VideoCloudBasicPlayer/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "VideoCloudBasicPlayer/VideoCloudBasicPlayer-Bridging-Header.h";
@@ -414,44 +355,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = VideoCloudBasicPlayer/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "VideoCloudBasicPlayer/VideoCloudBasicPlayer-Bridging-Header.h";
-			};
-			name = Release;
-		};
-		491576C219D9F2B700B2E657 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				INFOPLIST_FILE = VideoCloudBasicPlayerTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/VideoCloudBasicPlayer.app/VideoCloudBasicPlayer";
-			};
-			name = Debug;
-		};
-		491576C319D9F2B700B2E657 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
-				INFOPLIST_FILE = VideoCloudBasicPlayerTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/VideoCloudBasicPlayer.app/VideoCloudBasicPlayer";
 			};
 			name = Release;
 		};
@@ -472,15 +379,6 @@
 			buildConfigurations = (
 				491576BF19D9F2B700B2E657 /* Debug */,
 				491576C019D9F2B700B2E657 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		491576C119D9F2B700B2E657 /* Build configuration list for PBXNativeTarget "VideoCloudBasicPlayerTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				491576C219D9F2B700B2E657 /* Debug */,
-				491576C319D9F2B700B2E657 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Player/VideoCloudBasicPlayer/swift/VideoCloudBasicPlayer/AppDelegate.swift
+++ b/Player/VideoCloudBasicPlayer/swift/VideoCloudBasicPlayer/AppDelegate.swift
@@ -23,10 +23,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // for more information on how to use this in your own app.
 
         var categoryError :NSError?
-        var success = AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayback, error: &categoryError)
+        var success: Bool
+        do {
+            try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayback)
+            success = true
+        } catch let error as NSError {
+            categoryError = error
+            success = false
+        }
 
         if !success {
-            println("AppDelegate Debug - Error setting AVAudioSession category.  Because of this, there may be no sound. \(categoryError!)")
+            print("AppDelegate Debug - Error setting AVAudioSession category.  Because of this, there may be no sound. \(categoryError!)")
         }
 
         return true

--- a/Player/VideoCloudBasicPlayer/swift/VideoCloudBasicPlayer/Base.lproj/LaunchScreen.xib
+++ b/Player/VideoCloudBasicPlayer/swift/VideoCloudBasicPlayer/Base.lproj/LaunchScreen.xib
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6214" systemVersion="14A314h" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6207"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
     </dependencies>
     <objects>
@@ -11,7 +12,7 @@
             <rect key="frame" x="0.0" y="0.0" width="480" height="480"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2014 Brightcove. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2015 Brightcove. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
                     <rect key="frame" x="20" y="439" width="441" height="21"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>

--- a/Player/VideoCloudBasicPlayer/swift/VideoCloudBasicPlayer/Info.plist
+++ b/Player/VideoCloudBasicPlayer/swift/VideoCloudBasicPlayer/Info.plist
@@ -2,12 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.brightcove.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Player/VideoCloudBasicPlayer/swift/VideoCloudBasicPlayer/ViewController.swift
+++ b/Player/VideoCloudBasicPlayer/swift/VideoCloudBasicPlayer/ViewController.swift
@@ -19,7 +19,7 @@ class ViewController: UIViewController, BCOVPlaybackControllerDelegate {
     let playbackController :BCOVPlaybackController
     @IBOutlet weak var videoContainerView: UIView!
 
-    required init(coder aDecoder: NSCoder) {
+    required init?(coder aDecoder: NSCoder) {
         let manager = BCOVPlayerSDKManager.sharedManager();
         playbackController = manager.createPlaybackControllerWithViewStrategy(manager.defaultControlsViewStrategy())
 
@@ -35,7 +35,7 @@ class ViewController: UIViewController, BCOVPlaybackControllerDelegate {
         // Do any additional setup after loading the view, typically from a nib.
 
         playbackController.view.frame = videoContainerView.bounds
-        playbackController.view.autoresizingMask = .FlexibleHeight | .FlexibleWidth
+        playbackController.view.autoresizingMask = [.FlexibleHeight, .FlexibleWidth]
         videoContainerView.addSubview(playbackController.view)
 
         requestContentFromCatalog()


### PR DESCRIPTION
Summary of changes:

Project files:
 - enable testability YES
 - enable bitcode NO
 - deployment target 8.0
 - remove *Tests target
 - set product bundle identifier to `com.brightcove.$(PRODUCT_NAME:rfc1034identifier)`

Info.plist files:
 - replace `com.brightcove.$(PRODUCT_NAME:rfc1034identifier)` with `$(PRODUCT_BUNDLE_IDENTIFIER)`
 - disable AppTransportSecurity

Podfile.lock files:
 - update player sdk to 4.4.1
 - update plugins to latest version where applicable
 - update pod version to 0.38.2

LaunchImage.xib files:
 - update copyright date to 2015 where applicable

VideoCloudBasicPlayer (swift) 
 - updated to use latest Swift syntax

Testing:
All workspaces load, build and deploy iPhone 6+ (iOS 9.0) and iPhone 5 (iOS 8.4.1) without errors or warnings
Verified playback functionality

Other project updates are forthcoming, pending testing and addressing some warnings