### PR TITLE
Additional README.md cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ FairPlay samples demonstrate how to use the FairPlay plugin in Swift.
 To see an example of using FairPlay with IMA, refer to the FairPlayIMAPlayer sample app in the IMA folder.
 
 ###### A note about the FairPlay sample apps
-1. In both of the FairPlay sample apps, there are references to `FairPlayPublisherId` and `FairPlayApplicationId`. These terms refer to FairPlay credentials that Brightcove does not provide, which are instead acquired through Apple directly.
+In both of the FairPlay sample apps, there are references to `FairPlayPublisherId` and `FairPlayApplicationId`. These terms refer to FairPlay credentials that Brightcove does not provide, which are instead acquired through Apple directly.
 
 ##### FreeWheel
 
@@ -43,9 +43,6 @@ FreeWheel samples demonstrate how to use the FreeWheel plugin.
 ##### IMA
 
 IMA samples demonstrate how to use the IMA plugin. These are intended to cover use cases like VMAP, VAST, Server Side Ad rules, and advanced ad topics.
-
-##### IMA+Fairplay
-IMA+Fairplay samples show how to use FairPlay with the IMA ads plugin.
 
 ##### Omniture
 


### PR DESCRIPTION
@timothyrodgers @sahlas 
A couple of really minor changes:
1. Removed the reference to `IMA+FairPlay` since that directory does not exist.
2. Changed the formatting for the FairPlay note, to remove the list (since there's only one note anyway).