### PR TITLE
IMA sample app updates

### DIFF
--- a/IMA/BasicIMAPlayer/objc/BasicIMAPlayer/ViewController.m
+++ b/IMA/BasicIMAPlayer/objc/BasicIMAPlayer/ViewController.m
@@ -52,21 +52,35 @@ static NSString * const kViewControllerIMAVMAPResponseAdTag = @"http://pubads.g.
 {
     [super viewDidLoad];
     // Do any additional setup after loading the view, typically from a nib.
-    [self setup];
-    
-    BCOVPUIBasicControlView *controlView = [BCOVPUIBasicControlView basicControlViewWithVODLayout];
-    self.playerView = [[BCOVPUIPlayerView alloc] initWithPlaybackController:self.playbackController options:nil controlsView:controlView];
-    self.playerView.frame = self.videoContainer.bounds;
-    self.playerView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
-    [self.videoContainer addSubview:self.playerView];
-    
-    self.playerView.playbackController = self.playbackController;
 
+    [self setup];
     [self requestContentFromPlaybackService];
+}
+
+- (void)createPlayerView
+{
+    if (!self.playerView)
+    {
+        BCOVPUIPlayerViewOptions *options = [[BCOVPUIPlayerViewOptions alloc] init];
+        options.presentingViewController = self;
+        
+        BCOVPUIBasicControlView *controlView = [BCOVPUIBasicControlView basicControlViewWithVODLayout];
+        // Set playback controller later.
+        self.playerView = [[BCOVPUIPlayerView alloc] initWithPlaybackController:nil options:options controlsView:controlView];
+        self.playerView.frame = self.videoContainer.bounds;
+        self.playerView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+        [self.videoContainer addSubview:self.playerView];
+    }
+    else
+    {
+        NSLog(@"PlayerView already exists");
+    }
 }
 
 - (void)setup
 {
+    [self createPlayerView];
+
     BCOVPlayerSDKManager *manager = [BCOVPlayerSDKManager sharedManager];
 
     IMASettings *imaSettings = [[IMASettings alloc] init];
@@ -84,6 +98,8 @@ static NSString * const kViewControllerIMAVMAPResponseAdTag = @"http://pubads.g.
     self.playbackController.delegate = self;
     self.playbackController.autoAdvance = YES;
     self.playbackController.autoPlay = YES;
+
+    self.playerView.playbackController = self.playbackController;
 
     // Creating a playback controller based on the above code will create
     // VMAP / Server Side Ad Rules. These settings are explained in BCOVIMAAdsRequestPolicy.h.

--- a/IMA/BasicIMAPlayer/objc/BasicIMAPlayer/ViewController.m
+++ b/IMA/BasicIMAPlayer/objc/BasicIMAPlayer/ViewController.m
@@ -236,11 +236,24 @@ static NSString * const kViewControllerIMAVMAPResponseAdTag = @"http://pubads.g.
     }
 }
 
-#pragma mark UI Styling
-
-- (UIStatusBarStyle)preferredStatusBarStyle
+- (void)playbackController:(id<BCOVPlaybackController>)controller playbackSession:(id<BCOVPlaybackSession>)session didEnterAdSequence:(BCOVAdSequence *)adSequence
 {
-    return UIStatusBarStyleLightContent;
+    // Hide all controls for ads (so they're not visible when full-screen)
+    self.playerView.controlsContainerView.alpha = 0.0;
+}
+
+- (void)playbackController:(id<BCOVPlaybackController>)controller playbackSession:(id<BCOVPlaybackSession>)session didExitAdSequence:(BCOVAdSequence *)adSequence
+{
+    // Show all controls when ads are finished.
+    self.playerView.controlsContainerView.alpha = 1.0;
+}
+
+#pragma mark IMAWebOpenerDelegate Methods
+
+- (void)webOpenerDidCloseInAppBrowser:(NSObject *)webOpener
+{
+    // Called when the in-app browser has closed.
+    [self.playbackController resumeAd];
 }
 
 @end

--- a/IMA/FairPlayIMAPlayer/objc/FairPlayIMAPlayer/ViewController.m
+++ b/IMA/FairPlayIMAPlayer/objc/FairPlayIMAPlayer/ViewController.m
@@ -55,9 +55,31 @@ NSString * kFairPlayHLSVideoURL = @"http://example.com/fps/hlsvideo.m3u8";
     [self setup];
 }
 
+- (void)createPlayerView
+{
+    if (!self.playerView)
+    {
+        BCOVPUIPlayerViewOptions *options = [[BCOVPUIPlayerViewOptions alloc] init];
+        options.presentingViewController = self;
+        
+        BCOVPUIBasicControlView *controlView = [BCOVPUIBasicControlView basicControlViewWithVODLayout];
+        // Set playback controller later.
+        self.playerView = [[BCOVPUIPlayerView alloc] initWithPlaybackController:nil options:options controlsView:controlView];
+        self.playerView.frame = self.videoContainer.bounds;
+        self.playerView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+        [self.videoContainer addSubview:self.playerView];
+    }
+    else
+    {
+        NSLog(@"PlayerView already exists");
+    }
+}
+
 - (void)setup
 {
     NSLog(@"Setting up Brightcove objects");
+
+    [self createPlayerView];
 
     // Get the shared SDK manager
     BCOVPlayerSDKManager *sdkManager = [BCOVPlayerSDKManager sharedManager];
@@ -122,14 +144,7 @@ NSString * kFairPlayHLSVideoURL = @"http://example.com/fps/hlsvideo.m3u8";
 
             _playbackController = playbackController;
 
-            // Match the parent view and install
-            BCOVPUIBasicControlView *controlView = [BCOVPUIBasicControlView basicControlViewWithVODLayout];
-            self.playerView = [[BCOVPUIPlayerView alloc] initWithPlaybackController:_playbackController options:nil controlsView:controlView];
-            _playerView.frame = self.videoContainer.bounds;
-            _playerView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
-            [_videoContainer addSubview:self.playerView];
-
-            _playerView.playbackController = _playbackController;
+            self.playerView.playbackController = _playbackController;
 
             NSLog(@"Created a new playbackController");
 
@@ -137,7 +152,7 @@ NSString * kFairPlayHLSVideoURL = @"http://example.com/fps/hlsvideo.m3u8";
         }
         else
         {
-            NSLog(@"--- ERROR: FairPlay application certification not found ---");
+            NSLog(@"--- ERROR: FairPlay application certificate not found ---");
         }
 
     }];

--- a/IMA/FairPlayIMAPlayer/objc/FairPlayIMAPlayer/ViewController.m
+++ b/IMA/FairPlayIMAPlayer/objc/FairPlayIMAPlayer/ViewController.m
@@ -28,7 +28,7 @@ NSString * kFairPlayPublisherId = @"00000000-0000-0000-0000-000000000000";
 NSString * kFairPlayApplicationId = @"00000000-0000-0000-0000-000000000000";
 
 // FairPlay-protected content URL
-NSString * kFairPlayHLSVideoURL = @"http://example.com/fps/hlsvideo.m3u8";
+NSString * kFairPlayHLSVideoURL = @"https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_4x3/bipbop_4x3_variant.m3u8";
 
 
 @interface ViewController () <BCOVPlaybackControllerDelegate, IMAWebOpenerDelegate>

--- a/IMA/FairPlayIMAPlayer/objc/FairPlayIMAPlayer/ViewController.m
+++ b/IMA/FairPlayIMAPlayer/objc/FairPlayIMAPlayer/ViewController.m
@@ -268,4 +268,24 @@ NSString * kFairPlayHLSVideoURL = @"http://example.com/fps/hlsvideo.m3u8";
     }
 }
 
+- (void)playbackController:(id<BCOVPlaybackController>)controller playbackSession:(id<BCOVPlaybackSession>)session didEnterAdSequence:(BCOVAdSequence *)adSequence
+{
+    // Hide all controls for ads (so they're not visible when full-screen)
+    self.playerView.controlsContainerView.alpha = 0.0;
+}
+
+- (void)playbackController:(id<BCOVPlaybackController>)controller playbackSession:(id<BCOVPlaybackSession>)session didExitAdSequence:(BCOVAdSequence *)adSequence
+{
+    // Show all controls when ads are finished.
+    self.playerView.controlsContainerView.alpha = 1.0;
+}
+
+#pragma mark IMAWebOpenerDelegate Methods
+
+- (void)webOpenerDidCloseInAppBrowser:(NSObject *)webOpener
+{
+    // Called when the in-app browser has closed.
+    [self.playbackController resumeAd];
+}
+
 @end


### PR DESCRIPTION
1 - hide Brightcove controls when an IMA ad is playing so Brightcove controls don’t appear in unusual layouts during IMA ads
2 - resume ads when the in-app browser closes
3 - refactored player view creation (integrates PR 21)
4 - use a playable non-DRM URL for the FairPlay sample