### PR TITLE
Custom BrightCove By Using SwiftUI

### DIFF
--- a/SwiftUI/SwiftUIPlayerCustom/Podfile
+++ b/SwiftUI/SwiftUIPlayerCustom/Podfile
@@ -1,0 +1,12 @@
+source 'https://github.com/CocoaPods/Specs.git'
+source 'https://github.com/brightcove/BrightcoveSpecs.git'
+
+platform :ios, '13.0'
+use_frameworks!
+
+target 'SwiftUIPlayer' do
+
+  # Pods for SwiftUIPlayer
+  pod 'Brightcove-Player-Core/XCFramework'
+
+end

--- a/SwiftUI/SwiftUIPlayerCustom/SwiftUIPlayer.xcodeproj/project.pbxproj
+++ b/SwiftUI/SwiftUIPlayerCustom/SwiftUIPlayer.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1677C4D328DC23E1009168EE /* SliderBrightCoveSwiftUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1677C4D228DC23E1009168EE /* SliderBrightCoveSwiftUIView.swift */; };
 		AE94B43BF938E88A9A21DFDC /* Pods_SwiftUIPlayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CF415C5CE85421138C59DF58 /* Pods_SwiftUIPlayer.framework */; };
 		D6226168260927A3003CEF82 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6226167260927A3003CEF82 /* AppDelegate.swift */; };
 		D622616A260927A3003CEF82 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6226169260927A3003CEF82 /* SceneDelegate.swift */; };
@@ -18,6 +19,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		1677C4D228DC23E1009168EE /* SliderBrightCoveSwiftUIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SliderBrightCoveSwiftUIView.swift; sourceTree = "<group>"; };
 		A47013BCE0153E7BCB35BEF6 /* Pods-SwiftUIPlayer.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftUIPlayer.debug.xcconfig"; path = "Target Support Files/Pods-SwiftUIPlayer/Pods-SwiftUIPlayer.debug.xcconfig"; sourceTree = "<group>"; };
 		CD8E454B910F918FF4FCAFF5 /* Pods-SwiftUIPlayer.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftUIPlayer.release.xcconfig"; path = "Target Support Files/Pods-SwiftUIPlayer/Pods-SwiftUIPlayer.release.xcconfig"; sourceTree = "<group>"; };
 		CF415C5CE85421138C59DF58 /* Pods_SwiftUIPlayer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SwiftUIPlayer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -47,6 +49,7 @@
 		1677C4CF28DC1967009168EE /* PlayerUICustom */ = {
 			isa = PBXGroup;
 			children = (
+				1677C4D228DC23E1009168EE /* SliderBrightCoveSwiftUIView.swift */,
 			);
 			path = PlayerUICustom;
 			sourceTree = "<group>";
@@ -245,6 +248,7 @@
 				D6226168260927A3003CEF82 /* AppDelegate.swift in Sources */,
 				D622616A260927A3003CEF82 /* SceneDelegate.swift in Sources */,
 				D622616C260927A3003CEF82 /* ContentView.swift in Sources */,
+				1677C4D328DC23E1009168EE /* SliderBrightCoveSwiftUIView.swift in Sources */,
 				D6226191260959BB003CEF82 /* PlayerUI.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SwiftUI/SwiftUIPlayerCustom/SwiftUIPlayer.xcodeproj/project.pbxproj
+++ b/SwiftUI/SwiftUIPlayerCustom/SwiftUIPlayer.xcodeproj/project.pbxproj
@@ -1,0 +1,458 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 51;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		AE94B43BF938E88A9A21DFDC /* Pods_SwiftUIPlayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CF415C5CE85421138C59DF58 /* Pods_SwiftUIPlayer.framework */; };
+		D6226168260927A3003CEF82 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6226167260927A3003CEF82 /* AppDelegate.swift */; };
+		D622616A260927A3003CEF82 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6226169260927A3003CEF82 /* SceneDelegate.swift */; };
+		D622616C260927A3003CEF82 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D622616B260927A3003CEF82 /* ContentView.swift */; };
+		D622616E260927A5003CEF82 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D622616D260927A5003CEF82 /* Assets.xcassets */; };
+		D6226171260927A5003CEF82 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D6226170260927A5003CEF82 /* Preview Assets.xcassets */; };
+		D6226174260927A5003CEF82 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D6226172260927A5003CEF82 /* LaunchScreen.storyboard */; };
+		D6226191260959BB003CEF82 /* PlayerUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6226190260959BB003CEF82 /* PlayerUI.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		A47013BCE0153E7BCB35BEF6 /* Pods-SwiftUIPlayer.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftUIPlayer.debug.xcconfig"; path = "Target Support Files/Pods-SwiftUIPlayer/Pods-SwiftUIPlayer.debug.xcconfig"; sourceTree = "<group>"; };
+		CD8E454B910F918FF4FCAFF5 /* Pods-SwiftUIPlayer.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftUIPlayer.release.xcconfig"; path = "Target Support Files/Pods-SwiftUIPlayer/Pods-SwiftUIPlayer.release.xcconfig"; sourceTree = "<group>"; };
+		CF415C5CE85421138C59DF58 /* Pods_SwiftUIPlayer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SwiftUIPlayer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D6226164260927A3003CEF82 /* SwiftUIPlayer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftUIPlayer.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		D6226167260927A3003CEF82 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		D6226169260927A3003CEF82 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		D622616B260927A3003CEF82 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		D622616D260927A5003CEF82 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		D6226170260927A5003CEF82 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		D6226173260927A5003CEF82 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		D6226175260927A5003CEF82 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D6226190260959BB003CEF82 /* PlayerUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerUI.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		D6226161260927A3003CEF82 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AE94B43BF938E88A9A21DFDC /* Pods_SwiftUIPlayer.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		1677C4CF28DC1967009168EE /* PlayerUICustom */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = PlayerUICustom;
+			sourceTree = "<group>";
+		};
+		764B3C28EEA427A4B973FFEF /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				CF415C5CE85421138C59DF58 /* Pods_SwiftUIPlayer.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		D622615B260927A3003CEF82 = {
+			isa = PBXGroup;
+			children = (
+				D6226166260927A3003CEF82 /* SwiftUIPlayer */,
+				D6226165260927A3003CEF82 /* Products */,
+				F2AA9AF271DA4847A6BFCE20 /* Pods */,
+				764B3C28EEA427A4B973FFEF /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		D6226165260927A3003CEF82 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				D6226164260927A3003CEF82 /* SwiftUIPlayer.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		D6226166260927A3003CEF82 /* SwiftUIPlayer */ = {
+			isa = PBXGroup;
+			children = (
+				1677C4CF28DC1967009168EE /* PlayerUICustom */,
+				D6226167260927A3003CEF82 /* AppDelegate.swift */,
+				D6226169260927A3003CEF82 /* SceneDelegate.swift */,
+				D622616B260927A3003CEF82 /* ContentView.swift */,
+				D6226190260959BB003CEF82 /* PlayerUI.swift */,
+				D622616D260927A5003CEF82 /* Assets.xcassets */,
+				D6226172260927A5003CEF82 /* LaunchScreen.storyboard */,
+				D6226175260927A5003CEF82 /* Info.plist */,
+				D622616F260927A5003CEF82 /* Preview Content */,
+			);
+			path = SwiftUIPlayer;
+			sourceTree = "<group>";
+		};
+		D622616F260927A5003CEF82 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				D6226170260927A5003CEF82 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		F2AA9AF271DA4847A6BFCE20 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				A47013BCE0153E7BCB35BEF6 /* Pods-SwiftUIPlayer.debug.xcconfig */,
+				CD8E454B910F918FF4FCAFF5 /* Pods-SwiftUIPlayer.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		D6226163260927A3003CEF82 /* SwiftUIPlayer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D6226178260927A5003CEF82 /* Build configuration list for PBXNativeTarget "SwiftUIPlayer" */;
+			buildPhases = (
+				772A55A927DBC2083CF88379 /* [CP] Check Pods Manifest.lock */,
+				D6226160260927A3003CEF82 /* Sources */,
+				D6226161260927A3003CEF82 /* Frameworks */,
+				D6226162260927A3003CEF82 /* Resources */,
+				DE49B8896531DA9C999C20FA /* [CP] Embed Pods Frameworks */,
+				3773DF17AB14621B20E202B1 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SwiftUIPlayer;
+			productName = SwiftUIPlayer;
+			productReference = D6226164260927A3003CEF82 /* SwiftUIPlayer.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		D622615C260927A3003CEF82 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1240;
+				LastUpgradeCheck = 1240;
+				TargetAttributes = {
+					D6226163260927A3003CEF82 = {
+						CreatedOnToolsVersion = 12.4;
+					};
+				};
+			};
+			buildConfigurationList = D622615F260927A3003CEF82 /* Build configuration list for PBXProject "SwiftUIPlayer" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = D622615B260927A3003CEF82;
+			productRefGroup = D6226165260927A3003CEF82 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				D6226163260927A3003CEF82 /* SwiftUIPlayer */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		D6226162260927A3003CEF82 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D6226174260927A5003CEF82 /* LaunchScreen.storyboard in Resources */,
+				D6226171260927A5003CEF82 /* Preview Assets.xcassets in Resources */,
+				D622616E260927A5003CEF82 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		3773DF17AB14621B20E202B1 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-SwiftUIPlayer/Pods-SwiftUIPlayer-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-SwiftUIPlayer/Pods-SwiftUIPlayer-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-SwiftUIPlayer/Pods-SwiftUIPlayer-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		772A55A927DBC2083CF88379 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-SwiftUIPlayer-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		DE49B8896531DA9C999C20FA /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-SwiftUIPlayer/Pods-SwiftUIPlayer-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-SwiftUIPlayer/Pods-SwiftUIPlayer-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-SwiftUIPlayer/Pods-SwiftUIPlayer-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		D6226160260927A3003CEF82 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D6226168260927A3003CEF82 /* AppDelegate.swift in Sources */,
+				D622616A260927A3003CEF82 /* SceneDelegate.swift in Sources */,
+				D622616C260927A3003CEF82 /* ContentView.swift in Sources */,
+				D6226191260959BB003CEF82 /* PlayerUI.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		D6226172260927A5003CEF82 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				D6226173260927A5003CEF82 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		D6226176260927A5003CEF82 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VALIDATE_WORKSPACE = YES;
+			};
+			name = Debug;
+		};
+		D6226177260927A5003CEF82 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_BITCODE = NO;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+				VALIDATE_WORKSPACE = YES;
+			};
+			name = Release;
+		};
+		D6226179260927A5003CEF82 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A47013BCE0153E7BCB35BEF6 /* Pods-SwiftUIPlayer.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"SwiftUIPlayer/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = SwiftUIPlayer/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.companyname.SwiftUIPlayer;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		D622617A260927A5003CEF82 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CD8E454B910F918FF4FCAFF5 /* Pods-SwiftUIPlayer.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"SwiftUIPlayer/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = SwiftUIPlayer/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.companyname.SwiftUIPlayer;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		D622615F260927A3003CEF82 /* Build configuration list for PBXProject "SwiftUIPlayer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D6226176260927A5003CEF82 /* Debug */,
+				D6226177260927A5003CEF82 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D6226178260927A5003CEF82 /* Build configuration list for PBXNativeTarget "SwiftUIPlayer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D6226179260927A5003CEF82 /* Debug */,
+				D622617A260927A5003CEF82 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = D622615C260927A3003CEF82 /* Project object */;
+}

--- a/SwiftUI/SwiftUIPlayerCustom/SwiftUIPlayer/AppDelegate.swift
+++ b/SwiftUI/SwiftUIPlayerCustom/SwiftUIPlayer/AppDelegate.swift
@@ -1,0 +1,53 @@
+//
+//  AppDelegate.swift
+//  SwiftUIPlayer
+//
+//  Created by Carlos Ceja.
+//
+
+import AVFoundation
+import UIKit
+
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+
+        var categoryError :NSError?
+        var success: Bool
+        do {
+            // see https://developer.apple.com/documentation/avfoundation/avaudiosessioncategoryplayback
+            // and https://developer.apple.com/documentation/avfoundation/avaudiosessionmodemovieplayback
+            try AVAudioSession.sharedInstance().setCategory(.playback, mode: .moviePlayback, options: .duckOthers)
+            success = true
+        } catch let error as NSError {
+            categoryError = error
+            success = false
+        }
+
+        if !success {
+            print("AppDelegate Debug - Error setting AVAudioSession category.  Because of this, there may be no sound. \(categoryError!)")
+        }
+
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+
+
+}
+

--- a/SwiftUI/SwiftUIPlayerCustom/SwiftUIPlayer/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/SwiftUI/SwiftUIPlayerCustom/SwiftUIPlayer/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwiftUI/SwiftUIPlayerCustom/SwiftUIPlayer/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/SwiftUI/SwiftUIPlayerCustom/SwiftUIPlayer/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwiftUI/SwiftUIPlayerCustom/SwiftUIPlayer/Assets.xcassets/Contents.json
+++ b/SwiftUI/SwiftUIPlayerCustom/SwiftUIPlayer/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwiftUI/SwiftUIPlayerCustom/SwiftUIPlayer/Base.lproj/LaunchScreen.storyboard
+++ b/SwiftUI/SwiftUIPlayerCustom/SwiftUIPlayer/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Copyright © 2021 Brightcove. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="66X-pd-ulS">
+                                <rect key="frame" x="10" y="831" width="394" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SwiftUI" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xH0-2K-Vb2">
+                                <rect key="frame" x="154" y="427.5" width="106.5" height="41"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="66X-pd-ulS" secondAttribute="bottom" constant="10" id="DGp-jz-XHp"/>
+                            <constraint firstItem="xH0-2K-Vb2" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="JqI-L2-Aam"/>
+                            <constraint firstItem="xH0-2K-Vb2" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="XZQ-Ic-Ydh"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="66X-pd-ulS" secondAttribute="trailing" constant="10" id="b8f-vH-deg"/>
+                            <constraint firstItem="66X-pd-ulS" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="10" id="nDW-R6-5mR"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/SwiftUI/SwiftUIPlayerCustom/SwiftUIPlayer/ContentView.swift
+++ b/SwiftUI/SwiftUIPlayerCustom/SwiftUIPlayer/ContentView.swift
@@ -1,0 +1,99 @@
+//
+//  ContentView.swift
+//  SwiftUIPlayer
+//
+//  Created by Carlos Ceja.
+//
+
+import BrightcovePlayerSDK
+import SwiftUI
+
+struct Constants {
+    static let AccountID = "5434391461001"
+    static let PolicyKey =
+        "BCpkADawqM0T8lW3nMChuAbrcunBBHmh4YkNl5e6ZrKQwPiK_Y83RAOF4DP5tyBF_ONBVgrEjqW6fbV0nKRuHvjRU3E8jdT9WMTOXfJODoPML6NUDCYTwTHxtNlr5YdyGYaCPLhMUZ3Xu61L"
+    static let VideoId = "5702141808001"
+}
+
+struct ContentView: View {
+    @State var duration = Double.zero
+    @State var bufffer = Double.zero
+    @State var progress = Double.zero
+
+    var playbackController: BCOVPlaybackController = {
+        let fairPlayAuthProxy = BCOVFPSBrightcoveAuthProxy(publisherId: nil, applicationId: nil)!
+        let basicSessionProvider = BCOVPlayerSDKManager.sharedManager()?.createBasicSessionProvider(
+            with: nil)
+        let fairplaySessionProvider = BCOVPlayerSDKManager.sharedManager()?
+            .createFairPlaySessionProvider(
+                withApplicationCertificate: nil, authorizationProxy: fairPlayAuthProxy,
+                upstreamSessionProvider: basicSessionProvider)
+        let _playbackController = BCOVPlayerSDKManager.shared()?.createPlaybackController(
+            with: fairplaySessionProvider, viewStrategy: nil)
+        _playbackController?.isAutoPlay = true
+        _playbackController?.isAutoAdvance = true
+
+        return _playbackController!
+
+    }()
+
+    var playerView: BCOVPUIPlayerView = {
+
+        let options = BCOVPUIPlayerViewOptions()
+        options.automaticControlTypeSelection = false  // We don't using basic control view.
+
+        return BCOVPUIPlayerView(playbackController: nil, options: options, controlsView: nil)
+
+    }()
+
+    var body: some View {
+        VStack {
+            Text("Brightcove Player SwiftUI")
+                .bold()
+            ZStack {
+                PlayerUI(
+                    self.playbackController,
+                    self.playerView,
+                    duration: $duration,
+                    bufffer: $bufffer,
+                    progress: $progress
+                )
+                .aspectRatio(16 / 9, contentMode: .fit)
+                .onAppear {
+                    let playbackService = BCOVPlaybackService(
+                        accountId: Constants.AccountID, policyKey: Constants.PolicyKey)
+
+                    playbackService?.findVideo(
+                        withVideoID: Constants.VideoId, parameters: nil,
+                        completion: {
+                            (
+                                video: BCOVVideo?, jsonResponse: [AnyHashable: Any]?,
+                                error: Error?
+                            ) in
+
+                            if let video = video {
+                                self.playbackController.setVideos([video] as NSFastEnumeration)
+                            } else {
+                                print(
+                                    "ContentView Debug - Error retrieving video: \(error!.localizedDescription)"
+                                )
+                            }
+                        })
+                }
+                WrapperView()
+            }
+        }
+    }
+}
+
+struct WrapperView: View {
+    var body: some View {
+        Text("Wrraper View")
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/SwiftUI/SwiftUIPlayerCustom/SwiftUIPlayer/ContentView.swift
+++ b/SwiftUI/SwiftUIPlayerCustom/SwiftUIPlayer/ContentView.swift
@@ -19,6 +19,7 @@ struct ContentView: View {
     @State var duration = Double.zero
     @State var bufffer = Double.zero
     @State var progress = Double.zero
+    @State var isPlaying = false
 
     var playbackController: BCOVPlaybackController = {
         let fairPlayAuthProxy = BCOVFPSBrightcoveAuthProxy(publisherId: nil, applicationId: nil)!
@@ -32,68 +33,122 @@ struct ContentView: View {
             with: fairplaySessionProvider, viewStrategy: nil)
         _playbackController?.isAutoPlay = true
         _playbackController?.isAutoAdvance = true
-
         return _playbackController!
 
     }()
 
     var playerView: BCOVPUIPlayerView = {
-
         let options = BCOVPUIPlayerViewOptions()
         options.automaticControlTypeSelection = false  // We don't using basic control view.
-
         return BCOVPUIPlayerView(playbackController: nil, options: options, controlsView: nil)
-
     }()
 
     var body: some View {
         VStack {
             Text("Brightcove Player SwiftUI")
                 .bold()
-            ZStack {
-                PlayerUI(
-                    self.playbackController,
-                    self.playerView,
-                    duration: $duration,
-                    bufffer: $bufffer,
-                    progress: $progress
-                )
-                .aspectRatio(16 / 9, contentMode: .fit)
-                .onAppear {
-                    let playbackService = BCOVPlaybackService(
-                        accountId: Constants.AccountID, policyKey: Constants.PolicyKey)
+            PlayerUI(
+                self.playbackController,
+                self.playerView,
+                duration: $duration,
+                bufffer: $bufffer,
+                progress: $progress,
+                isPlay: $isPlaying
+            )
+            .overlay(controlView)
+            .aspectRatio(16/9, contentMode: .fit)
 
-                    playbackService?.findVideo(
-                        withVideoID: Constants.VideoId, parameters: nil,
-                        completion: {
-                            (
-                                video: BCOVVideo?, jsonResponse: [AnyHashable: Any]?,
-                                error: Error?
-                            ) in
+        }
+        .onAppear {
+            let playbackService = BCOVPlaybackService(
+                accountId: Constants.AccountID, policyKey: Constants.PolicyKey)
+            playbackService?.findVideo(
+                withVideoID: Constants.VideoId, parameters: nil,
+                completion: {
+                    (
+                        video: BCOVVideo?, jsonResponse: [AnyHashable: Any]?,
+                        error: Error?
+                    ) in
 
-                            if let video = video {
-                                self.playbackController.setVideos([video] as NSFastEnumeration)
-                            } else {
-                                print(
-                                    "ContentView Debug - Error retrieving video: \(error!.localizedDescription)"
-                                )
-                            }
-                        })
-                }
-                WrapperView()
-            }
+                    if let video = video {
+                        self.playbackController.setVideos([video] as NSFastEnumeration)
+                    } else {
+                        print(
+                            "ContentView Debug - Error retrieving video: \(error!.localizedDescription)"
+                        )
+                    }
+                })
         }
     }
 }
 
-struct WrapperView: View {
-    var body: some View {
-        Text("Wrraper View")
+extension ContentView {
+    var controlView: some View {
+        VStack(spacing: 0) {
+            Spacer()
+            HStack {
+                Text(progress.asString(style: .positional))
+                    .font(.system(size: 12))
+                    .fontWeight(.regular)
+                SliderBrightCoveSwiftUIView(value: $progress, buffer: $bufffer, duration: $duration) {
+                    value in
+                    playerView.playbackController.seek(
+                        to: CMTime(seconds: progress, preferredTimescale: CMTimeScale(1.0)),
+                        toleranceBefore: .zero, toleranceAfter: .zero
+                    ) { sliderChangeValue in
+                        if sliderChangeValue { print("Slider progress changed") }
+                    }
+                }
+                Text(duration.asString(style: .positional))
+                    .font(.system(size: 12))
+                    .fontWeight(.regular)
+            }
+            HStack {
+                Spacer()
+                Button {
+                    playerView.playbackController.seek(
+                        to: CMTime(seconds: progress - 10, preferredTimescale: CMTimeScale(1.0))
+                    ) { back in
+                        if back { print("Back - 10 second") }
+                    }
+                } label: {
+                    Image(systemName: "gobackward.10")
+                }
+                Button {
+                    isPlaying
+                        ? playerView.playbackController.pause()
+                        : playerView.playbackController.play()
+                } label: {
+                    Image(systemName: isPlaying ? "pause" : "play")
+                        .padding()
+                }
+                Button {
+                    playerView.playbackController.seek(
+                        to: CMTime(seconds: progress + 10, preferredTimescale: CMTimeScale(1.0))
+                    ) { next in
+                        if next { print("Next + 10 second") }
+                    }
+                } label: { Image(systemName: "goforward.10") }
+                Spacer()
+            }
+            .foregroundColor(.white)
+        }
+        .padding(8)
     }
 }
 
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
         ContentView()
+    }
+}
+
+extension Double {
+    func asString(style: DateComponentsFormatter.UnitsStyle) -> String {
+        if self.isInfinite || self.isNaN { return "" }
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.hour, .minute, .second, .nanosecond]
+        formatter.unitsStyle = style
+        return formatter.string(from: self) ?? ""
     }
 }

--- a/SwiftUI/SwiftUIPlayerCustom/SwiftUIPlayer/Info.plist
+++ b/SwiftUI/SwiftUIPlayerCustom/SwiftUIPlayer/Info.plist
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/SwiftUI/SwiftUIPlayerCustom/SwiftUIPlayer/PlayerUI.swift
+++ b/SwiftUI/SwiftUIPlayerCustom/SwiftUIPlayer/PlayerUI.swift
@@ -12,69 +12,142 @@ struct PlayerUI: UIViewRepresentable {
     @Binding var duration: Double
     @Binding var bufffer: Double
     @Binding var progress: Double
-
+    @Binding var isPlay: Bool
     var playbackController: BCOVPlaybackController
     var playerView: BCOVPUIPlayerView
 
     init(
-        _ playbackController: BCOVPlaybackController, _ playerView: BCOVPUIPlayerView,
+        _ playbackController: BCOVPlaybackController,
+        _ playerView: BCOVPUIPlayerView,
         duration: Binding<Double>,
         bufffer: Binding<Double>,
-        progress: Binding<Double>
+        progress: Binding<Double>,
+        isPlay: Binding<Bool>
     ) {
-
         self.playbackController = playbackController
         self.playerView = playerView
         _duration = duration
         _bufffer = bufffer
         _progress = progress
+        _isPlay = isPlay
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator()
+        Coordinator(duration: $duration, bufffer: $bufffer, progress: $progress, isPlay: $isPlay)
     }
 
     func makeUIView(context: Context) -> BCOVPUIPlayerView {
-
         self.playerView.playbackController = self.playbackController
         self.playerView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
-
         self.playbackController.delegate = context.coordinator
-
         return self.playerView
     }
 
     func updateUIView(_ uiView: BCOVPUIPlayerView, context: Context) {
-
     }
 
     class Coordinator: NSObject, BCOVPlaybackControllerDelegate {
+        @Binding var duration: Double
+        @Binding var bufffer: Double
+        @Binding var progress: Double
+        @Binding var isPlay: Bool
 
-        func playbackController(
-            _ controller: BCOVPlaybackController?, didAdvanceTo session: BCOVPlaybackSession?
+        init(
+            duration: Binding<Double>,
+            bufffer: Binding<Double>,
+            progress: Binding<Double>,
+            isPlay: Binding<Bool>
         ) {
-            print("Coordinator Debug - Advanced to new session.")
+            _duration = duration
+            _bufffer = bufffer
+            _progress = progress
+            _isPlay = isPlay
+        }
+
+        // Buffer Can Caclutor Refer: https://stackoverflow.com/questions/7691854/avplayer-streaming-progress
+        func availableDuration(player: AVPlayer) -> TimeInterval {
+            let loadedTimeRanges = player.currentItem?.loadedTimeRanges
+            let timeRange = loadedTimeRanges?.first?.timeRangeValue
+            var startSeconds: Float64? = nil
+            if let start = timeRange?.start {
+                startSeconds = CMTimeGetSeconds(start)
+            }
+            var durationSeconds: Float64? = nil
+            if let duration = timeRange?.duration {
+                durationSeconds = CMTimeGetSeconds(duration)
+            }
+            let result = TimeInterval((startSeconds ?? 0) + (durationSeconds ?? 0))
+            return result
+        }
+
+        // BCOVPlaybackController Protocol
+        func playbackController(
+            _ controller: BCOVPlaybackController!, didAdvanceTo session: BCOVPlaybackSession!
+        ) {
+            if let item = session.player.currentItem {
+                if item.responds(to: NSSelectorFromString("preferredForwardBufferDuration")) {
+                    guard session.player != nil else { return }
+                    bufffer = availableDuration(player: session.player)
+                }
+            }
+        }
+        func playbackController(
+            _ controller: BCOVPlaybackController!, playbackSession session: BCOVPlaybackSession!,
+            didProgressTo progress: TimeInterval
+        ) {
+            self.progress = progress
+            guard !(progress.isNaN || progress.isInfinite) else {
+                return
+            }
+            self.progress = progress.rounded()
+            if let currentItem = session?.player.currentItem {
+                if currentItem.responds(to: NSSelectorFromString("preferredForwardBufferDuration")) {
+                    bufffer = availableDuration(player: session.player)
+                }
+            }
         }
 
         func playbackController(
-            _ controller: BCOVPlaybackController?, playbackSession session: BCOVPlaybackSession?,
-            didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent?
+            _ controller: BCOVPlaybackController!, playbackSession session: BCOVPlaybackSession!,
+            didChangeDuration duration: TimeInterval
         ) {
-            if let eventType = lifecycleEvent?.eventType {
-                print("Coordinator Debug - Event Type: \(eventType)")
+            self.duration = duration.rounded()
+        }
+
+        func playbackController(
+            _ controller: BCOVPlaybackController!, playbackSession session: BCOVPlaybackSession!,
+            didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!
+        ) {
+
+            switch lifecycleEvent.eventType {
+            case kBCOVPlaybackSessionLifecycleEventPlay:
+                isPlay = true
+            case kBCOVPlaybackSessionLifecycleEventPause:
+                isPlay = false
+            case kBCOVPlaybackSessionLifecycleEventResumeFail:
+                print("resumeFail")
+            case kBCOVPlaybackSessionLifecycleEventResumeBegin:
+                print("play")
+            case kBCOVPlaybackSessionLifecycleEventFail:
+                print("failedToLoad")
+            case kBCOVPlaybackSessionLifecycleEventError:
+                print("error")
+            case kBCOVPlaybackSessionLifecycleEventPlaybackBufferEmpty:
+                do {
+                    guard !(self.progress.isNaN || self.progress.isInfinite) else {
+                        break
+                    }
+                }
+            case kBCOVPlaybackSessionLifecycleEventPlaybackLikelyToKeepUp:
+                do {
+                    guard !(self.progress.isNaN || self.progress.isInfinite) else {
+                        break
+                    }
+                }
+            default: break
             }
         }
     }
 
     typealias UIViewType = BCOVPUIPlayerView
-}
-
-struct PlayerUI_Previews: PreviewProvider {
-
-    static var playbackController = BCOVPlayerSDKManager.shared()?.createPlaybackController()
-    static var playerView = BCOVPUIPlayerView(playbackController: playbackController)
-
-    static var previews: some View {
-        PlayerUI(playbackController!, playerView!)
-    }
 }

--- a/SwiftUI/SwiftUIPlayerCustom/SwiftUIPlayer/PlayerUI.swift
+++ b/SwiftUI/SwiftUIPlayerCustom/SwiftUIPlayer/PlayerUI.swift
@@ -1,0 +1,80 @@
+//
+//  PlayerUI.swift
+//  SwiftUIPlayer
+//
+//  Created by Carlos Ceja.
+//
+
+import BrightcovePlayerSDK
+import SwiftUI
+
+struct PlayerUI: UIViewRepresentable {
+    @Binding var duration: Double
+    @Binding var bufffer: Double
+    @Binding var progress: Double
+
+    var playbackController: BCOVPlaybackController
+    var playerView: BCOVPUIPlayerView
+
+    init(
+        _ playbackController: BCOVPlaybackController, _ playerView: BCOVPUIPlayerView,
+        duration: Binding<Double>,
+        bufffer: Binding<Double>,
+        progress: Binding<Double>
+    ) {
+
+        self.playbackController = playbackController
+        self.playerView = playerView
+        _duration = duration
+        _bufffer = bufffer
+        _progress = progress
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeUIView(context: Context) -> BCOVPUIPlayerView {
+
+        self.playerView.playbackController = self.playbackController
+        self.playerView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
+
+        self.playbackController.delegate = context.coordinator
+
+        return self.playerView
+    }
+
+    func updateUIView(_ uiView: BCOVPUIPlayerView, context: Context) {
+
+    }
+
+    class Coordinator: NSObject, BCOVPlaybackControllerDelegate {
+
+        func playbackController(
+            _ controller: BCOVPlaybackController?, didAdvanceTo session: BCOVPlaybackSession?
+        ) {
+            print("Coordinator Debug - Advanced to new session.")
+        }
+
+        func playbackController(
+            _ controller: BCOVPlaybackController?, playbackSession session: BCOVPlaybackSession?,
+            didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent?
+        ) {
+            if let eventType = lifecycleEvent?.eventType {
+                print("Coordinator Debug - Event Type: \(eventType)")
+            }
+        }
+    }
+
+    typealias UIViewType = BCOVPUIPlayerView
+}
+
+struct PlayerUI_Previews: PreviewProvider {
+
+    static var playbackController = BCOVPlayerSDKManager.shared()?.createPlaybackController()
+    static var playerView = BCOVPUIPlayerView(playbackController: playbackController)
+
+    static var previews: some View {
+        PlayerUI(playbackController!, playerView!)
+    }
+}

--- a/SwiftUI/SwiftUIPlayerCustom/SwiftUIPlayer/PlayerUICustom/SliderBrightCoveSwiftUIView.swift
+++ b/SwiftUI/SwiftUIPlayerCustom/SwiftUIPlayer/PlayerUICustom/SliderBrightCoveSwiftUIView.swift
@@ -1,0 +1,62 @@
+//
+//  SliderBrightCoveSwiftUIView.swift
+//  SwiftUIPlayer
+//
+//  Created by Lê Quang Trọng Tài on 9/22/22.
+//
+
+import BrightcovePlayerSDK
+import Foundation
+import SwiftUI
+
+struct SliderBrightCoveSwiftUIView: UIViewRepresentable {
+    @Binding var value: Double
+    @Binding var buffer: Double
+    @Binding var duration: Double
+    var onValueChange: (Float) -> Void?
+
+    func makeUIView(context: Context) -> BCOVPUISlider {
+        let slider = BCOVPUISlider(frame: .zero)
+        slider.value = Float(value)
+        slider.minimumValue = .zero
+        slider.maximumValue = Float(duration)
+        slider.addTarget(
+            context.coordinator, action: #selector(Coordinator.onValueChanged(_:)),
+            for: .valueChanged)
+        return slider
+    }
+
+    func updateUIView(_ uiView: BCOVPUISlider, context: Context) {
+        uiView.value = Float(self.value)
+        uiView.maximumValue = Float(self.duration)
+        uiView.bufferProgress = Float(self.buffer)
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(value: $value, buffer: $buffer, onValueChanged: onValueChange)
+    }
+
+    //MARK: Coordinator
+    class Coordinator: NSObject {
+        var value: Binding<Double>
+        var buffer: Binding<Double>
+        var onValueChange: (Float) -> Void?
+
+        init(
+            value: Binding<Double>, buffer: Binding<Double>,
+            onValueChanged: @escaping (Float) -> Void?
+        ) {
+            self.value = value
+            self.buffer = buffer
+            self.onValueChange = onValueChanged
+        }
+
+        @objc
+        func onValueChanged(_ sender: BCOVPUISlider) {
+            self.value.wrappedValue = Double(sender.value)
+            self.buffer.wrappedValue = Double(sender.bufferProgress)
+            onValueChange(sender.value)
+        }
+    }
+    typealias UIViewType = BCOVPUISlider
+}

--- a/SwiftUI/SwiftUIPlayerCustom/SwiftUIPlayer/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/SwiftUI/SwiftUIPlayerCustom/SwiftUIPlayer/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwiftUI/SwiftUIPlayerCustom/SwiftUIPlayer/SceneDelegate.swift
+++ b/SwiftUI/SwiftUIPlayerCustom/SwiftUIPlayer/SceneDelegate.swift
@@ -1,0 +1,60 @@
+//
+//  SceneDelegate.swift
+//  SwiftUIPlayer
+//
+//  Created by Carlos Ceja.
+//
+
+import UIKit
+import SwiftUI
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+
+        // Create the SwiftUI view that provides the window contents.
+        let contentView = ContentView()
+
+        // Use a UIHostingController as window root view controller.
+        if let windowScene = scene as? UIWindowScene {
+            let window = UIWindow(windowScene: windowScene)
+            window.rootViewController = UIHostingController(rootView: contentView)
+            self.window = window
+            window.makeKeyAndVisible()
+        }
+    }
+    
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+    
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+    
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+    
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+    
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+
+}


### PR DESCRIPTION
With SwiftUI, We could do more by using View. Brightcove has public PlayerUIView. We could add a wrapper to it. Instead using the default control view in UIKit. It takes time to custom, handle color, size, frame, padding.. etc in UIKit on SwiftUI Project. So I had written this example for anyone approach Brightcove with SwiftUI.