### PR TITLE
Removed extra AVAudioSession set up

### DIFF
--- a/SwiftUI/SwiftUIPlayer/SwiftUIPlayer/SwiftUIPlayer.swift
+++ b/SwiftUI/SwiftUIPlayer/SwiftUIPlayer/SwiftUIPlayer.swift
@@ -15,27 +15,7 @@ struct SwiftUIPlayer: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
-                .onAppear {
-                    setUpAudioSession()
-                }
         }
     }
-    
-    private func setUpAudioSession() {
-        var categoryError :NSError?
-        var success: Bool
-        do {
-            // see https://developer.apple.com/documentation/avfoundation/avaudiosessioncategoryplayback
-            // and https://developer.apple.com/documentation/avfoundation/avaudiosessionmodemovieplayback
-            try AVAudioSession.sharedInstance().setCategory(.playback, mode: .moviePlayback, options: .duckOthers)
-            success = true
-        } catch let error as NSError {
-            categoryError = error
-            success = false
-        }
 
-        if !success {
-            print("AppDelegate Debug - Error setting AVAudioSession category.  Because of this, there may be no sound. \(categoryError!)")
-        }
-    }
 }


### PR DESCRIPTION
Set up occurs in the AppDelegate https://github.com/BrightcoveOS/ios-player-samples/blob/master/SwiftUI/SwiftUIPlayer/SwiftUIPlayer/AppDelegate.swift