### PR TITLE
#feat: Implement thumbnail video

### DIFF
--- a/Player/SubtitleRendering/swift/SubtitleRendering/ViewController.swift
+++ b/Player/SubtitleRendering/swift/SubtitleRendering/ViewController.swift
@@ -48,7 +48,7 @@ class ViewController: UIViewController {
     
     private func setupPlaybackController() {
         playbackController = (BCOVPlayerSDKManager.shared().createPlaybackController())!
-                
+        playbackController?.thumbnailSeekingEnabled = true
         playbackController?.delegate = self
         playbackController?.isAutoPlay = true
     }

--- a/SwiftUI/SwiftUICustomControls/SwiftUICustomControls.xcodeproj/project.pbxproj
+++ b/SwiftUI/SwiftUICustomControls/SwiftUICustomControls.xcodeproj/project.pbxproj
@@ -8,6 +8,11 @@
 
 /* Begin PBXBuildFile section */
 		1677C4D328DC23E1009168EE /* CustomSliderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1677C4D228DC23E1009168EE /* CustomSliderView.swift */; };
+		16CD19CD2B94D6C90010258C /* ThumbnailModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CD19CC2B94D6C90010258C /* ThumbnailModel.swift */; };
+		16CD19CF2B94D7DA0010258C /* Double+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CD19CE2B94D7DA0010258C /* Double+Extension.swift */; };
+		3E4C8A512B970980006A3C71 /* UISlider+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E4C8A502B970980006A3C71 /* UISlider+Extension.swift */; };
+		3E4C8A532B970EFF006A3C71 /* ThumbnailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E4C8A522B970EFF006A3C71 /* ThumbnailView.swift */; };
+		3EDDD2E82B8EE475004D9DB9 /* ThumbnailManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EDDD2E72B8EE475004D9DB9 /* ThumbnailManager.swift */; };
 		D622616C260927A3003CEF82 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D622616B260927A3003CEF82 /* ContentView.swift */; };
 		D622616E260927A5003CEF82 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D622616D260927A5003CEF82 /* Assets.xcassets */; };
 		D6226171260927A5003CEF82 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D6226170260927A5003CEF82 /* Preview Assets.xcassets */; };
@@ -25,6 +30,11 @@
 
 /* Begin PBXFileReference section */
 		1677C4D228DC23E1009168EE /* CustomSliderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomSliderView.swift; sourceTree = "<group>"; };
+		16CD19CC2B94D6C90010258C /* ThumbnailModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailModel.swift; sourceTree = "<group>"; };
+		16CD19CE2B94D7DA0010258C /* Double+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Extension.swift"; sourceTree = "<group>"; };
+		3E4C8A502B970980006A3C71 /* UISlider+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UISlider+Extension.swift"; sourceTree = "<group>"; };
+		3E4C8A522B970EFF006A3C71 /* ThumbnailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailView.swift; sourceTree = "<group>"; };
+		3EDDD2E72B8EE475004D9DB9 /* ThumbnailManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailManager.swift; sourceTree = "<group>"; };
 		D6226164260927A3003CEF82 /* SwiftUICustomControls.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftUICustomControls.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D622616B260927A3003CEF82 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		D622616D260927A5003CEF82 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -72,9 +82,11 @@
 		D6226166260927A3003CEF82 /* SwiftUICustomControls */ = {
 			isa = PBXGroup;
 			children = (
+				16CD19CE2B94D7DA0010258C /* Double+Extension.swift */,
 				E9392E302A5EF97D00FB951A /* AppDelegate.swift */,
 				E9AF8DC12A577A94001C8EB0 /* Int+DurationFormat.swift */,
 				E9AF8DC52A577B14001C8EB0 /* SwiftUICustomControls.swift */,
+				3E4C8A502B970980006A3C71 /* UISlider+Extension.swift */,
 				E9AF8DC32A577ABC001C8EB0 /* Models */,
 				E9AF8DC42A577ACF001C8EB0 /* Views */,
 				D622616D260927A5003CEF82 /* Assets.xcassets */,
@@ -96,8 +108,10 @@
 		E9AF8DC32A577ABC001C8EB0 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				3EDDD2E72B8EE475004D9DB9 /* ThumbnailManager.swift */,
 				D6AD6EF12AB0C18500CCA159 /* PlayerModel.swift */,
 				E9AF8DBD2A57657D001C8EB0 /* VideoModel.swift */,
+				16CD19CC2B94D6C90010258C /* ThumbnailModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -110,6 +124,7 @@
 				1677C4D228DC23E1009168EE /* CustomSliderView.swift */,
 				D6226190260959BB003CEF82 /* PlayerUIView.swift */,
 				D67A0A702AAF6D260038CE45 /* VideoView.swift */,
+				3E4C8A522B970EFF006A3C71 /* ThumbnailView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -194,12 +209,17 @@
 				E9AF8DBE2A57657D001C8EB0 /* VideoModel.swift in Sources */,
 				E9AF8DC62A577B14001C8EB0 /* SwiftUICustomControls.swift in Sources */,
 				E9392E312A5EF97D00FB951A /* AppDelegate.swift in Sources */,
+				3EDDD2E82B8EE475004D9DB9 /* ThumbnailManager.swift in Sources */,
 				D622616C260927A3003CEF82 /* ContentView.swift in Sources */,
 				E9AF8DC02A577715001C8EB0 /* CustomControlsView.swift in Sources */,
 				D67A0A712AAF6D260038CE45 /* VideoView.swift in Sources */,
+				3E4C8A512B970980006A3C71 /* UISlider+Extension.swift in Sources */,
+				16CD19CD2B94D6C90010258C /* ThumbnailModel.swift in Sources */,
 				1677C4D328DC23E1009168EE /* CustomSliderView.swift in Sources */,
 				D6226191260959BB003CEF82 /* PlayerUIView.swift in Sources */,
+				3E4C8A532B970EFF006A3C71 /* ThumbnailView.swift in Sources */,
 				D6AD6EF22AB0C18500CCA159 /* PlayerModel.swift in Sources */,
+				16CD19CF2B94D7DA0010258C /* Double+Extension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SwiftUI/SwiftUICustomControls/SwiftUICustomControls/Double+Extension.swift
+++ b/SwiftUI/SwiftUICustomControls/SwiftUICustomControls/Double+Extension.swift
@@ -1,0 +1,16 @@
+//
+//  Double+Extension.swift
+//  SwiftUICustomControls
+//
+//  Created by Lê Quang Trọng Tài on 3/3/24.
+//
+
+import Foundation
+import CoreMedia
+
+// MARK: - Double Extension
+extension Double {
+    var asCMTime: CMTime {
+        CMTime(seconds: self, preferredTimescale: CMTimeScale(60))
+    }
+}

--- a/SwiftUI/SwiftUICustomControls/SwiftUICustomControls/Models/PlayerModel.swift
+++ b/SwiftUI/SwiftUICustomControls/SwiftUICustomControls/Models/PlayerModel.swift
@@ -15,8 +15,9 @@ final class PlayerModel: NSObject, ObservableObject, BCOVPlaybackControllerDeleg
     @Published var buffer: Double = .zero
     @Published var progress: Double = .zero
     @Published var isPlaying = false
+    @Published var isShowThumbnail = false
     @Published var showControls = true
-
+    var thumbnailManager: ThumbnailManager?
     private(set) lazy var controller: BCOVPlaybackController? = {
         let sdkManager = BCOVPlayerSDKManager.shared()
 
@@ -28,6 +29,7 @@ final class PlayerModel: NSObject, ObservableObject, BCOVPlaybackControllerDeleg
             return nil
         }
 
+        _playbackController.thumbnailSeekingEnabled = false
         _playbackController.delegate = self
         _playbackController.isAutoPlay = true
         _playbackController.isAutoAdvance = false
@@ -61,7 +63,7 @@ final class PlayerModel: NSObject, ObservableObject, BCOVPlaybackControllerDeleg
     }
 
     func playbackController(_ controller: BCOVPlaybackController!, playbackSession session: BCOVPlaybackSession!, didChangeDuration duration: TimeInterval) {
-        self.duration = duration.rounded()
+        self.duration = duration.rounded(.towardZero)
     }
 
     func playbackController(_ controller: BCOVPlaybackController!, playbackSession session: BCOVPlaybackSession!, didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {

--- a/SwiftUI/SwiftUICustomControls/SwiftUICustomControls/Models/ThumbnailManager.swift
+++ b/SwiftUI/SwiftUICustomControls/SwiftUICustomControls/Models/ThumbnailManager.swift
@@ -1,0 +1,187 @@
+//
+//  ThumbnailManager.swift
+//  SwiftUICustomControls
+//
+//  Created by iletai on 28/02/2024.
+//
+
+import Foundation
+import UIKit
+import CoreMedia
+import Combine
+
+final class ThumbnailManager {
+    private var cancellables = [AnyCancellable]()
+    private var thumbnails: [ThumbnailModel]?
+    private let cache = NSCache<NSString, UIImage>()
+    private let session: URLSession
+
+    init(url: URL) {
+        self.session = URLSession(configuration: .default)
+        fetchThumbnailData(url: url)
+    }
+    
+    /// Get Thumbnail Video View
+    /// - Parameter time: At Current Time
+    /// - Returns: UIImage?
+    func thumbnailAtTime(_ time: CMTime) -> UIImage? {
+        guard let thumbnails = thumbnails else {
+            return nil
+        }
+        for thumbnail in thumbnails {
+            if let startTime = thumbnail.startTime,
+                let endTime = thumbnail.endTime {
+                if startTime...endTime ~= time {
+                    if let thumbnailCachePath = thumbnail.url?.absoluteString {
+                        return get(forKey: thumbnailCachePath)
+                    }
+                }
+            }
+        }
+        return nil
+    }
+    
+    /// Combine Load And Save Image To NSCache
+    /// - Parameter urlCache: URL Path Cache
+    /// - Returns: AnyPublisher<UIImage, Error>
+    func loadAndCacheThumbnail(_ urlCachePath: String) -> AnyPublisher<UIImage, Error> {
+        Future<UIImage, Error> { [weak self] promise in
+            guard let self else {
+                promise(.failure(ThumbnailError.fetchError))
+                return
+            }
+            if let cachedImage = get(forKey: urlCachePath) {
+                promise(.success(cachedImage))
+                return
+            }
+
+            guard let url = URL(string: urlCachePath) else {
+                promise(.failure(ThumbnailError.urlNotFound))
+                return
+            }
+
+            let task = session.dataTask(with: url) { data, response, error in
+                guard let data = data, error == nil else { return }
+                DispatchQueue.global().async {
+                    guard let image = UIImage(data: data) else {
+                        promise(.failure(ThumbnailError.decodeError))
+                        return
+                    }
+                    self.set(image, forKey: urlCachePath)
+                    promise(.success(image))
+                }
+            }
+            task.resume()
+        }
+        .eraseToAnyPublisher()
+    }
+}
+
+// MARK: - Private Function
+private extension ThumbnailManager {
+    func fetchThumbnailData(url: URL) {
+        let task = session.dataTask(
+            with: URLRequest(url: url)
+        ) { [weak self] (data: Data?, response: URLResponse?, error: Error?) in
+            guard let self = self else { return }
+            if let error = error {
+                print("Fetch Thumbnail Error With Description: \(error.localizedDescription)")
+                return
+            }
+            guard let data = data,
+                    let thumbnailData = String(data: data, encoding: .utf8) else {
+                return
+            }
+            DispatchQueue.global().async {
+                self.parseThumbnail(thumbnailData)
+            }
+        }
+        task.resume()
+    }
+
+    func parseThumbnail(_ thumbnail: String) {
+        let lines =  thumbnail.components(separatedBy: "\n").filter { !$0.isEmpty }
+        var _thumbnails = [ThumbnailModel]()
+        var currentThumbnail: ThumbnailModel?
+        for line in lines {
+            do {
+                let regex = try NSRegularExpression(pattern: "([0-9]{2}):([0-9]{2}).([0-9]{3}) --> ([0-9]{2}):([0-9]{2}).([0-9]{3})", options: .caseInsensitive)
+                let matches = regex.matches(in: line, options: NSRegularExpression.MatchingOptions(rawValue: 0), range: NSMakeRange(0, line.count))
+                if matches.count == 1 {
+                    if let result = matches.first {
+                        let startTimeMinuteRange = result.range(at: 1)
+                        let startTimeSecondRange = result.range(at: 2)
+                        let startTimeMSRange = result.range(at: 3)
+                        let endTimeMinuteRange = result.range(at: 4)
+                        let endTimeSecondRange = result.range(at: 5)
+                        let endTimeMSRange = result.range(at: 6)
+                        guard let startTimeMinute = Double((line as NSString).substring(with: startTimeMinuteRange)), let startTimeSecond = Double((line as NSString).substring(with: startTimeSecondRange)), let startTimeMS = Double((line as NSString).substring(with: startTimeMSRange)), let endTimeMinute = Double((line as NSString).substring(with: endTimeMinuteRange)), let endTimeSecond = Double((line as NSString).substring(with: endTimeSecondRange)), let endTimeMS = Double((line as NSString).substring(with: endTimeMSRange)) else {
+                            break;
+                        }
+
+                        let startTime = (startTimeMinute * 60.0 * 60.0) + (startTimeSecond * 60) + (startTimeMS / 1000)
+
+                        let endTime = (endTimeMinute * 60.0 * 60.0) + (endTimeSecond * 60) + (endTimeMS / 1000)
+
+                        if let currentThumbnail = currentThumbnail {
+                            _thumbnails.append(currentThumbnail)
+                        }
+
+                        // Create a new instance and assign the time range
+                        let _currentThumbnail = ThumbnailModel()
+                        _currentThumbnail.startTime = CMTimeMake(value: Int64(startTime), timescale: 60)
+                        _currentThumbnail.endTime = CMTimeMake(value: Int64(endTime), timescale: 60)
+                        currentThumbnail = _currentThumbnail
+                    }
+                }
+
+                if matches.count == 0 && line.count > 0 {
+                    if let currentThumbnail = currentThumbnail {
+                        guard let urlParse = URL(string: line) else {
+                            break
+                        }
+                        currentThumbnail.url = urlParse
+                        loadAndCacheThumbnail(urlParse.absoluteString)
+                            .receive(on: RunLoop.main)
+                            .sink(receiveCompletion: { completion in
+                                switch completion {
+                                case .finished:
+                                    break
+                                case .failure(let failure):
+                                    print("Cache Video Thumbnail Error: \(failure.localizedDescription)")
+                                }
+                            }, receiveValue: { _ in
+                            })
+                            .store(in: &cancellables)
+                        if let lastItem = lines.last, !lastItem.isEmpty, lastItem == line {
+                            _thumbnails.append(currentThumbnail)
+                        }
+                    }
+                }
+
+            } catch {
+                print("Error creating regex")
+                break
+            }
+
+        }
+        thumbnails = _thumbnails
+    }
+}
+
+// MARK: - Cache Set/Get
+extension ThumbnailManager {
+    func set(_ image: UIImage, forKey key: String) {
+        cache.setObject(image, forKey: key as NSString)
+    }
+
+    func get(forKey key: String) -> UIImage? {
+        cache.object(forKey: key as NSString)
+    }
+}
+
+enum ThumbnailError: Error {
+    case fetchError
+    case decodeError
+    case urlNotFound
+}

--- a/SwiftUI/SwiftUICustomControls/SwiftUICustomControls/Models/ThumbnailModel.swift
+++ b/SwiftUI/SwiftUICustomControls/SwiftUICustomControls/Models/ThumbnailModel.swift
@@ -1,0 +1,16 @@
+//
+//  ThumbnailModel.swift
+//  SwiftUICustomControls
+//
+//  Created by Lê Quang Trọng Tài on 3/3/24.
+//
+
+import Foundation
+import CoreMedia
+import UIKit
+
+class ThumbnailModel {
+    var startTime: CMTime?
+    var endTime: CMTime?
+    var url: URL?
+}

--- a/SwiftUI/SwiftUICustomControls/SwiftUICustomControls/Models/VideoModel.swift
+++ b/SwiftUI/SwiftUICustomControls/SwiftUICustomControls/Models/VideoModel.swift
@@ -23,7 +23,7 @@ final class VideoModel {
         return Future<BCOVVideo, Error> { promise in
             let configuration = [kBCOVPlaybackServiceConfigurationKeyAssetID:Constants.VideoId]
             let playbackService = BCOVPlaybackService(accountId: Constants.AccountID, policyKey: Constants.PolicyKey)
-
+            
             playbackService?.findVideo(withConfiguration: configuration, queryParameters: nil) { video, jsonResponse, error in
                 if let video = video {
                     promise(.success(video))

--- a/SwiftUI/SwiftUICustomControls/SwiftUICustomControls/UISlider+Extension.swift
+++ b/SwiftUI/SwiftUICustomControls/SwiftUICustomControls/UISlider+Extension.swift
@@ -1,0 +1,29 @@
+//
+//  UISlider+Extension.swift
+//  SwiftUICustomControls
+//
+//  Created by iletai on 05/03/2024.
+//
+
+import Foundation
+import UIKit
+
+// MARK: - UISlider Extension
+extension UISlider {
+    var trackBounds: CGRect {
+        return trackRect(forBounds: bounds)
+    }
+
+    var trackFrame: CGRect {
+        guard let superView = superview else { return CGRect.zero }
+        return self.convert(trackBounds, to: superView)
+    }
+
+    var thumbBounds: CGRect {
+        return thumbRect(forBounds: frame, trackRect: trackBounds, value: value)
+    }
+
+    var thumbFrame: CGRect {
+        return thumbRect(forBounds: bounds, trackRect: trackFrame, value: value)
+    }
+}

--- a/SwiftUI/SwiftUICustomControls/SwiftUICustomControls/Views/CustomControlsView.swift
+++ b/SwiftUI/SwiftUICustomControls/SwiftUICustomControls/Views/CustomControlsView.swift
@@ -18,69 +18,77 @@ struct CustomControlsView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            HStack {
-                Text(playerModel.progress.convertDurationToString())
-                    .font(.system(size: labelFontSize))
-                    .fontWeight(.regular)
-                    .foregroundColor(Color.white)
-                    .multilineTextAlignment(.center)
-                    .padding(EdgeInsets(top: 0, leading: 15, bottom: 0, trailing: 15))
-
-                CustomSliderView(value: $playerModel.progress) { value in
-                    playerModel.controller?.seek(to: CMTime(seconds: playerModel.progress, preferredTimescale: CMTimeScale(1.0)), toleranceBefore: .zero, toleranceAfter: .zero) { sliderChangeValue in
-                        if sliderChangeValue { print("Slider progress changed") }
+            VStack(spacing: 0) {
+                HStack {
+                    Text(playerModel.progress.convertDurationToString())
+                        .font(.system(size: labelFontSize))
+                        .fontWeight(.regular)
+                        .foregroundColor(Color.white)
+                        .multilineTextAlignment(.center)
+                        .padding(EdgeInsets(top: 0, leading: 15, bottom: 0, trailing: 15))
+                    CustomSliderView {
+                        ThumbnailView()
+                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                            .frame(width: 100, height: 60)
+                    } onValueChanged: { value in
+                        playerModel.controller?.seek(to: CMTime(seconds: playerModel.progress, preferredTimescale: CMTimeScale(1.0)), toleranceBefore: .zero, toleranceAfter: .zero) { sliderChangeValue in
+                            if sliderChangeValue { print("Slider progress changed") }
+                        }
+                    } onTouchSliderEvent: { _, _, isTrack in
+                        withAnimation(isTrack ? .linear : nil) {
+                            playerModel.isShowThumbnail = isTrack
+                        }
                     }
+
+                    Text(playerModel.duration.convertDurationToString())
+                        .font(.system(size: labelFontSize))
+                        .fontWeight(.regular)
+                        .foregroundColor(Color.white)
+                        .multilineTextAlignment(.center)
+                        .padding(EdgeInsets(top: 0, leading: 15, bottom: 0, trailing: 15))
                 }
 
-                Text(playerModel.duration.convertDurationToString())
-                    .font(.system(size: labelFontSize))
-                    .fontWeight(.regular)
-                    .foregroundColor(Color.white)
-                    .multilineTextAlignment(.center)
-                    .padding(EdgeInsets(top: 0, leading: 15, bottom: 0, trailing: 15))
-            }
+                HStack {
+                    Spacer()
 
-            HStack {
-                Spacer()
-                
-                Button {
-                    playerModel.controller?.seek(to: CMTime(seconds: playerModel.progress - 10, preferredTimescale: CMTimeScale(1.0))) { back in
-                    if back { print("Back - 10 second") }
-                }
-                } label: {
-                    Image(systemName: "gobackward.10")
-                        .resizable()
-                        .frame(width: buttonSize, height: buttonSize)
-                }
-
-                Button {
-                    playerModel.isPlaying ? playerModel.controller?.pause() : playerModel.controller?.play()
-                } label: {
-                    Image(systemName: playerModel.isPlaying ? "pause" : "play")
-                        .resizable()
-                        .frame(width: buttonSize, height: buttonSize)
-                        .padding()
-                }
-
-                Button {
-                    playerModel.controller?.seek(to: CMTime(seconds: playerModel.progress + 10, preferredTimescale: CMTimeScale(1.0))) { next in
-                        if next { print("Next + 10 second") }
+                    Button {
+                        playerModel.controller?.seek(to: CMTime(seconds: playerModel.progress - 10, preferredTimescale: CMTimeScale(1.0))) { back in
+                            if back { print("Back - 10 second") }
+                        }
+                    } label: {
+                        Image(systemName: "gobackward.10")
+                            .resizable()
+                            .frame(width: buttonSize, height: buttonSize)
                     }
-                } label: {
-                    Image(systemName: "goforward.10")
-                        .resizable()
-                        .frame(width: buttonSize, height: buttonSize)
-                }
 
-                Spacer()
+                    Button {
+                        playerModel.isPlaying ? playerModel.controller?.pause() : playerModel.controller?.play()
+                    } label: {
+                        Image(systemName: playerModel.isPlaying ? "pause" : "play")
+                            .resizable()
+                            .frame(width: buttonSize, height: buttonSize)
+                            .padding()
+                    }
+
+                    Button {
+                        playerModel.controller?.seek(to: CMTime(seconds: playerModel.progress + 10, preferredTimescale: CMTimeScale(1.0))) { next in
+                            if next { print("Next + 10 second") }
+                        }
+                    } label: {
+                        Image(systemName: "goforward.10")
+                            .resizable()
+                            .frame(width: buttonSize, height: buttonSize)
+                    }
+
+                    Spacer()
+                }
+                .foregroundColor(.white)
             }
-            .foregroundColor(.white)
+            .padding(8)
+            .background(Color.black.opacity(0.5))
         }
-        .padding(8)
-        .background(Color.black.opacity(0.5))
     }
 }
-
 
 // MARK: -
 

--- a/SwiftUI/SwiftUICustomControls/SwiftUICustomControls/Views/ThumbnailView.swift
+++ b/SwiftUI/SwiftUICustomControls/SwiftUICustomControls/Views/ThumbnailView.swift
@@ -1,0 +1,33 @@
+//
+//  ThumbnailView.swift
+//  SwiftUICustomControls
+//
+//  Created by iletai on 05/03/2024.
+//
+
+import Foundation
+import SwiftUI
+
+struct ThumbnailView: View {
+    @EnvironmentObject var playerModel: PlayerModel
+    var body: some View {
+        if playerModel.isShowThumbnail {
+            if let image = playerModel.thumbnailManager?.thumbnailAtTime(playerModel.progress.asCMTime) {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFit()
+                    .aspectRatio(contentMode: .fit)
+            } else {
+                loadingView
+            }
+        }
+    }
+
+    /// Loading View
+    var loadingView: some View {
+        Color
+            .gray
+            .opacity(0.2)
+            .overlay(ProgressView())
+    }
+}


### PR DESCRIPTION
## Description
With SwiftUI framework. Currently, custom thumbnails for videos have just not been released. I faced with the case Swiftui and Brightcove has a little information about that, but it's really difficult to research.
When communicating with @jblaker, with a suggestion, I clearly about that feature. I research and implement for case custom SwiftUI before
I expect to help someone when implementing features related to BrightCove on SwiftUI. 

## Feature / Bug Fix

- [x] Thumbnail Video has been added.
- [x] Fix duration of custom SwiftUi view not mapping with UIKit video example

## Related Changes
- Add `ThumbnailView`, and `ThumbnailManager` examples to get and show thumbnail videos in the SDK
- Update `CustomSliderView` with clear init and event tracking when touching on the slider

## Smoke Testing
- [x] I have tested these changes on the simulator.
- [x] I have tested these changes in a real device.

## Development Environment

- Operating System: macOS 14.0
- Compiler: Xcode 15.1
- Dependencies: Brightcove Player SDK for iOS, version 6.12.7.2564

## Reviewers

@jblaker 

Please help me to process and take a look at it when you have time.
## Screenshots (If Applicable)

<video src="https://github.com/BrightcoveOS/ios-player-samples/assets/26614687/05bfa7a2-ac3a-45dc-b1f0-651309ff899d" width="300">



