### PR TITLE
feat: add local SDK development support via BRIGHTCOVE_LOCAL_SDK

### DIFF
--- a/DAI/BasicDAIPlayer-iOS/Podfile
+++ b/DAI/BasicDAIPlayer-iOS/Podfile
@@ -1,3 +1,5 @@
+require_relative '../../Podfile.common'
+
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
@@ -6,5 +8,5 @@ platform :ios, '14.0'
 use_frameworks!
 
 target 'BasicDAIPlayer' do
-  pod 'Brightcove-Player-DAI/XCFramework'
+  brightcove_pod 'Brightcove-Player-DAI'
 end

--- a/DAI/BasicDAIPlayer-tvOS/Podfile
+++ b/DAI/BasicDAIPlayer-tvOS/Podfile
@@ -1,3 +1,5 @@
+require_relative '../../Podfile.common'
+
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
@@ -6,5 +8,5 @@ platform :tvos, '14.0'
 use_frameworks!
 
 target 'BasicDAIPlayer' do
-  pod 'Brightcove-Player-DAI/XCFramework'
+  brightcove_pod 'Brightcove-Player-DAI'
 end

--- a/FairPlay/BasicFairPlayPlayer-iOS/Podfile
+++ b/FairPlay/BasicFairPlayPlayer-iOS/Podfile
@@ -1,3 +1,5 @@
+require_relative '../../Podfile.common'
+
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
@@ -6,5 +8,5 @@ platform :ios, '12.0'
 use_frameworks!
 
 target 'BasicFairPlayPlayer' do
-  pod 'Brightcove-Player-Core/XCFramework'
+  brightcove_pod 'Brightcove-Player-Core'
 end

--- a/Freewheel/BasicFreeWheelPlayer-iOS/Podfile
+++ b/Freewheel/BasicFreeWheelPlayer-iOS/Podfile
@@ -1,3 +1,5 @@
+require_relative '../../Podfile.common'
+
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
@@ -6,5 +8,5 @@ platform :ios, '12.0'
 use_frameworks!
 
 target 'BasicFreeWheelPlayer' do
-  pod 'Brightcove-Player-FreeWheel/XCFramework'
+  brightcove_pod 'Brightcove-Player-FreeWheel'
 end

--- a/GoogleCast/BasicCastPlayer/Podfile
+++ b/GoogleCast/BasicCastPlayer/Podfile
@@ -1,3 +1,5 @@
+require_relative '../../Podfile.common'
+
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
@@ -6,5 +8,5 @@ platform :ios, '14.0'
 use_frameworks!
 
 target 'BasicCastPlayer' do
-  pod 'Brightcove-Player-GoogleCast/XCFramework'
+  brightcove_pod 'Brightcove-Player-GoogleCast'
 end

--- a/GoogleCast/BrightcoveCastReceiver/Podfile
+++ b/GoogleCast/BrightcoveCastReceiver/Podfile
@@ -1,3 +1,5 @@
+require_relative '../../Podfile.common'
+
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
@@ -6,5 +8,5 @@ platform :ios, '14.0'
 use_frameworks!
 
 target 'BrightcoveCastReceiver' do
-  pod 'Brightcove-Player-GoogleCast/XCFramework'
+  brightcove_pod 'Brightcove-Player-GoogleCast'
 end

--- a/IMA/BasicIMAPlayer-iOS/Podfile
+++ b/IMA/BasicIMAPlayer-iOS/Podfile
@@ -1,3 +1,5 @@
+require_relative '../../Podfile.common'
+
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
@@ -6,5 +8,5 @@ platform :ios, '14.0'
 use_frameworks!
 
 target 'BasicIMAPlayer' do
-  pod 'Brightcove-Player-IMA/XCFramework'
+  brightcove_pod 'Brightcove-Player-IMA'
 end

--- a/IMA/NativeControlsIMAPlayer-tvOS/Podfile
+++ b/IMA/NativeControlsIMAPlayer-tvOS/Podfile
@@ -1,3 +1,5 @@
+require_relative '../../Podfile.common'
+
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
@@ -6,5 +8,5 @@ platform :tvos, '14.0'
 use_frameworks!
 
 target 'NativeControlsIMAPlayer' do
-  pod 'Brightcove-Player-IMA/XCFramework'
+  brightcove_pod 'Brightcove-Player-IMA'
 end

--- a/Offline/OfflinePlayer/Podfile
+++ b/Offline/OfflinePlayer/Podfile
@@ -1,3 +1,5 @@
+require_relative '../../Podfile.common'
+
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
@@ -6,5 +8,5 @@ platform :ios, '12.0'
 use_frameworks!
 
 target 'OfflinePlayer' do
-  pod 'Brightcove-Player-Core/XCFramework'
+  brightcove_pod 'Brightcove-Player-Core'
 end

--- a/Omniture/BasicOmniturePlayer/Podfile
+++ b/Omniture/BasicOmniturePlayer/Podfile
@@ -1,3 +1,5 @@
+require_relative '../../Podfile.common'
+
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
@@ -6,5 +8,5 @@ platform :ios, '12.0'
 use_frameworks!
 
 target 'BasicOmniturePlayer' do
-  pod 'Brightcove-Player-Omniture/XCFramework'
+  brightcove_pod 'Brightcove-Player-Omniture'
 end

--- a/Player/AppleTV/Podfile
+++ b/Player/AppleTV/Podfile
@@ -1,3 +1,5 @@
+require_relative '../../Podfile.common'
+
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
@@ -6,5 +8,5 @@ platform :tvos, '12.0'
 use_frameworks!
 
 target 'AppleTV' do
-  pod 'Brightcove-Player-Core/XCFramework'
+  brightcove_pod 'Brightcove-Player-Core'
 end

--- a/Player/CustomControls/Podfile
+++ b/Player/CustomControls/Podfile
@@ -1,3 +1,5 @@
+require_relative '../../Podfile.common'
+
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
@@ -6,5 +8,5 @@ platform :ios, '12.0'
 use_frameworks!
 
 target 'CustomControls' do
-  pod 'Brightcove-Player-Core/XCFramework'
+  brightcove_pod 'Brightcove-Player-Core'
 end

--- a/Player/DVRLive/Podfile
+++ b/Player/DVRLive/Podfile
@@ -1,3 +1,5 @@
+require_relative '../../Podfile.common'
+
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
@@ -6,5 +8,5 @@ platform :ios, '12.0'
 use_frameworks!
 
 target 'DVRLive' do
-  pod 'Brightcove-Player-Core/XCFramework'
+  brightcove_pod 'Brightcove-Player-Core'
 end

--- a/Player/NativeControls/Podfile
+++ b/Player/NativeControls/Podfile
@@ -1,3 +1,5 @@
+require_relative '../../Podfile.common'
+
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
@@ -6,5 +8,5 @@ platform :ios, '12.0'
 use_frameworks!
 
 target 'NativeControls' do
-  pod 'Brightcove-Player-Core/XCFramework'
+  brightcove_pod 'Brightcove-Player-Core'
 end

--- a/Player/SubtitleRendering/Podfile
+++ b/Player/SubtitleRendering/Podfile
@@ -1,3 +1,5 @@
+require_relative '../../Podfile.common'
+
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
@@ -6,5 +8,5 @@ platform :ios, '12.0'
 use_frameworks!
 
 target 'SubtitleRendering' do
-  pod 'Brightcove-Player-Core/XCFramework'
+  brightcove_pod 'Brightcove-Player-Core'
 end

--- a/Player/TableViewPlayer/Podfile
+++ b/Player/TableViewPlayer/Podfile
@@ -1,3 +1,5 @@
+require_relative '../../Podfile.common'
+
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
@@ -6,5 +8,5 @@ platform :ios, '12.0'
 use_frameworks!
 
 target 'TableViewPlayer' do
-  pod 'Brightcove-Player-Core/XCFramework'
+  brightcove_pod 'Brightcove-Player-Core'
 end

--- a/Player/Video360/Podfile
+++ b/Player/Video360/Podfile
@@ -1,3 +1,5 @@
+require_relative '../../Podfile.common'
+
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
@@ -6,5 +8,5 @@ platform :ios, '12.0'
 use_frameworks!
 
 target 'Video360Player' do
-  pod 'Brightcove-Player-Core/XCFramework'
+  brightcove_pod 'Brightcove-Player-Core'
 end

--- a/Player/VideoCloudBasicPlayer/Podfile
+++ b/Player/VideoCloudBasicPlayer/Podfile
@@ -1,3 +1,5 @@
+require_relative '../../Podfile.common'
+
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
@@ -6,5 +8,5 @@ platform :ios, '12.0'
 use_frameworks!
 
 target 'VideoCloudBasicPlayer' do
-  pod 'Brightcove-Player-Core/XCFramework'
+  brightcove_pod 'Brightcove-Player-Core'
 end

--- a/Player/VideoPreloading/Podfile
+++ b/Player/VideoPreloading/Podfile
@@ -1,3 +1,5 @@
+require_relative '../../Podfile.common'
+
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
@@ -6,5 +8,5 @@ platform :ios, '12.0'
 use_frameworks!
 
 target 'VideoPreloading' do
-  pod 'Brightcove-Player-Core/XCFramework'
+  brightcove_pod 'Brightcove-Player-Core'
 end

--- a/PlayerUI/Flutter/Podfile
+++ b/PlayerUI/Flutter/Podfile
@@ -1,3 +1,5 @@
+require_relative '../../Podfile.common'
+
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
@@ -11,7 +13,7 @@ load File.join(flutter_application_path, '.ios', 'Flutter', 'podhelper.rb')
 target 'FlutterPlayer' do
 
   install_all_flutter_pods(flutter_application_path)
-  pod 'Brightcove-Player-IMA/XCFramework'
+  brightcove_pod 'Brightcove-Player-IMA'
 
   post_install do |installer|
     flutter_post_install(installer)

--- a/PlayerUI/PlayerUICustomization/Podfile
+++ b/PlayerUI/PlayerUICustomization/Podfile
@@ -1,3 +1,5 @@
+require_relative '../../Podfile.common'
+
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
@@ -6,5 +8,5 @@ platform :ios, '12.0'
 use_frameworks!
 
 target 'PlayerUICustomization' do
-  pod 'Brightcove-Player-Core/XCFramework'
+  brightcove_pod 'Brightcove-Player-Core'
 end

--- a/PlayerUI/ReactNative/ios/Podfile
+++ b/PlayerUI/ReactNative/ios/Podfile
@@ -1,3 +1,5 @@
+require_relative '../../../Podfile.common'
+
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
@@ -22,7 +24,7 @@ target 'ReactNativePlayer' do
   config = use_native_modules!
   use_react_native!(:path => config[:reactNativePath],:app_path => "#{Pod::Config.instance.installation_root}/..")
 
-  pod 'Brightcove-Player-IMA/XCFramework'
+  brightcove_pod 'Brightcove-Player-IMA'
 
   post_install do |installer|
     # https://github.com/facebook/react-native/blob/main/packages/react-native/scripts/react_native_pods.rb#L197-L202

--- a/PlayerUI/ViewStrategy/Podfile
+++ b/PlayerUI/ViewStrategy/Podfile
@@ -1,3 +1,5 @@
+require_relative '../../Podfile.common'
+
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
@@ -6,5 +8,5 @@ platform :ios, '12.0'
 use_frameworks!
 
 target 'ViewStrategy' do
-  pod 'Brightcove-Player-Core/XCFramework'
+  brightcove_pod 'Brightcove-Player-Core'
 end

--- a/Podfile.common.rb
+++ b/Podfile.common.rb
@@ -1,0 +1,107 @@
+# Podfile.common.rb
+# Shared CocoaPods configuration for Brightcove iOS Player Samples
+#
+# This helper enables seamless switching between published SDK versions
+# and local SDK development builds.
+#
+# Usage:
+#   - Published SDK (default): Just run `pod install`
+#   - Local SDK (default path): BRIGHTCOVE_LOCAL_SDK=true pod install
+#   - Local SDK (custom path):  BRIGHTCOVE_LOCAL_SDK=/path/to/sdk pod install
+#
+# The default local SDK path is ../videocloud_agave (sibling directory)
+
+# Mapping from published pod names to local podspec info
+# Format: 'Published-Pod-Name' => ['LocalPodspecName', 'relative/path/from/sdk/root']
+BRIGHTCOVE_POD_MAPPING = {
+  'Brightcove-Player-Core'            => ['BCOVPlayerSDK',   'src/core'],
+  'Brightcove-Player-IMA'             => ['BCOVIMA',         'src/ima'],
+  'Brightcove-Player-DAI'             => ['BCOVDAI',         'src/dai'],
+  'Brightcove-Player-SSAI'            => ['BCOVSSAI',        'src/ssai'],
+  'Brightcove-Player-FreeWheel'       => ['BCOVFW',          'src/freewheel'],
+  'Brightcove-Player-Pulse'           => ['BCOVPulse',       'src/pulse'],
+  'Brightcove-Player-Omniture'        => ['BCOVAMC',         'src/omniture'],
+  'Brightcove-Player-GoogleCast'      => ['BCOVGoogleCast',  'src/googlecast'],
+  'Brightcove-Player-OpenMeasurement' => ['BCOVOM',          'src/ssai'],
+}.freeze
+
+DEFAULT_LOCAL_SDK_PATH = '../videocloud_agave'
+
+# Track registered local pods to avoid duplicates within a single Podfile evaluation
+$brightcove_registered_local_pods ||= {}
+$brightcove_registered_local_pods.clear
+
+# Determine if we're using local SDK and get the path
+def brightcove_local_sdk_path
+  env_value = ENV['BRIGHTCOVE_LOCAL_SDK']
+  return nil if env_value.nil? || env_value.empty?
+
+  # If set to 'true', '1', or 'yes', use default path
+  if %w[true 1 yes].include?(env_value.downcase)
+    DEFAULT_LOCAL_SDK_PATH
+  else
+    # Otherwise, treat the value as a custom path
+    env_value
+  end
+end
+
+# Internal helper to register a local pod
+def _register_local_brightcove_pod(name, local_sdk_path)
+  return if $brightcove_registered_local_pods[name]
+
+  mapping = BRIGHTCOVE_POD_MAPPING[name]
+  return if mapping.nil?
+
+  local_name, relative_path = mapping
+
+  # Resolve the SDK path relative to this file's directory (repo root)
+  common_file_dir = File.dirname(__FILE__)
+  sdk_root = File.expand_path(local_sdk_path, common_file_dir)
+  resolved_path = File.join(sdk_root, relative_path)
+
+  unless File.exist?(resolved_path)
+    raise "Local SDK not found at #{resolved_path}. Check BRIGHTCOVE_LOCAL_SDK path or use published version."
+  end
+
+  Pod::UI.puts "Using local pod: #{local_name} from #{resolved_path}".yellow
+  pod local_name, :path => resolved_path
+  $brightcove_registered_local_pods[name] = true
+end
+
+# Helper to declare a Brightcove pod with automatic local/published switching
+#
+# @param name [String] The published pod name (e.g., 'Brightcove-Player-Core')
+# @param subspec [String] The subspec to use for published pods (default: '/XCFramework')
+#
+# Examples:
+#   brightcove_pod 'Brightcove-Player-Core'
+#   brightcove_pod 'Brightcove-Player-IMA'
+#
+def brightcove_pod(name, subspec: '/XCFramework')
+  local_sdk_path = brightcove_local_sdk_path
+
+  if local_sdk_path
+    mapping = BRIGHTCOVE_POD_MAPPING[name]
+
+    if mapping.nil?
+      raise "Unknown Brightcove pod: #{name}. Add it to BRIGHTCOVE_POD_MAPPING in Podfile.common.rb"
+    end
+
+    # For plugin pods, automatically include the core SDK as a dependency
+    # since local podspecs have 'dependency BCOVPlayerSDK'
+    if name != 'Brightcove-Player-Core'
+      _register_local_brightcove_pod('Brightcove-Player-Core', local_sdk_path)
+    end
+
+    _register_local_brightcove_pod(name, local_sdk_path)
+  else
+    pod "#{name}#{subspec}"
+  end
+end
+
+# Print SDK mode on load
+if brightcove_local_sdk_path
+  Pod::UI.puts "Brightcove SDK: Using LOCAL build from #{brightcove_local_sdk_path}".green
+else
+  Pod::UI.puts "Brightcove SDK: Using PUBLISHED version".green
+end

--- a/Pulse/BasicPulsePlayer-iOS/Podfile
+++ b/Pulse/BasicPulsePlayer-iOS/Podfile
@@ -1,3 +1,5 @@
+require_relative '../../Podfile.common'
+
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
@@ -6,5 +8,5 @@ platform :ios, '12.0'
 use_frameworks!
 
 target 'BasicPulsePlayer' do
-  pod 'Brightcove-Player-Pulse/XCFramework'
+  brightcove_pod 'Brightcove-Player-Pulse'
 end

--- a/Pulse/BasicPulsePlayer-tvOS/Podfile
+++ b/Pulse/BasicPulsePlayer-tvOS/Podfile
@@ -1,3 +1,5 @@
+require_relative '../../Podfile.common'
+
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
@@ -6,5 +8,5 @@ platform :tvos, '12.0'
 use_frameworks!
 
 target 'BasicPulsePlayer' do
-  pod 'Brightcove-Player-Pulse/XCFramework'
+  brightcove_pod 'Brightcove-Player-Pulse'
 end

--- a/README.md
+++ b/README.md
@@ -21,6 +21,34 @@ To ensure you are using the latest releases of the Brightcove software component
 pod repo update
 ```
 
+### Using a Local SDK Build
+
+For SDK development, you can easily switch between the published SDK and a local development build by setting the `BRIGHTCOVE_LOCAL_SDK` environment variable.
+
+**Using the default local path (`../videocloud_agave`):**
+```bash
+BRIGHTCOVE_LOCAL_SDK=true pod install
+```
+
+**Using a custom path:**
+```bash
+BRIGHTCOVE_LOCAL_SDK=/path/to/your/sdk pod install
+```
+
+**Using the published SDK (default behavior):**
+```bash
+pod install
+```
+
+When using local SDK mode:
+- The helper automatically maps published pod names (e.g., `Brightcove-Player-Core`) to local podspec names (e.g., `BCOVPlayerSDK`)
+- Console output indicates which mode is active
+- If the local SDK path doesn't exist, the build will fail with a clear error message
+
+This feature is configured in `Podfile.common.rb` at the repository root.
+
+**Note:** Some samples use Swift Package Manager (SPM) instead of CocoaPods (e.g., `SwiftUI/CustomControls-iOS`). The local SDK switching feature only applies to CocoaPods-based samples.
+
 ### About Bitcode
 
 The ENABLE_BITCODE setting has been removed from all sample projects and the default value of the IDE is used instead. Xcode 14.0 has deprecated bitcode and the default setting is NO. The default bitcode setting in Xcode 13 is YES.

--- a/SSAI/BasicSSAIPlayer-iOS/Podfile
+++ b/SSAI/BasicSSAIPlayer-iOS/Podfile
@@ -1,3 +1,5 @@
+require_relative '../../Podfile.common'
+
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
@@ -6,8 +8,8 @@ platform :ios, '12.0'
 use_frameworks!
 
 target 'BasicSSAIPlayer' do
-  pod 'Brightcove-Player-SSAI/XCFramework'
+  brightcove_pod 'Brightcove-Player-SSAI'
 
   # Open Measurement
-  # pod 'Brightcove-Player-OpenMeasurement'
+  # brightcove_pod 'Brightcove-Player-OpenMeasurement'
 end

--- a/SSAI/BasicSSAIPlayer-tvOS/Podfile
+++ b/SSAI/BasicSSAIPlayer-tvOS/Podfile
@@ -1,3 +1,5 @@
+require_relative '../../Podfile.common'
+
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
@@ -6,5 +8,5 @@ platform :tvos, '12.0'
 use_frameworks!
 
 target 'BasicSSAIPlayer' do
-  pod 'Brightcove-Player-SSAI/XCFramework'
+  brightcove_pod 'Brightcove-Player-SSAI'
 end

--- a/SSAI/SLS+IMA-iOS/Podfile
+++ b/SSAI/SLS+IMA-iOS/Podfile
@@ -1,3 +1,5 @@
+require_relative '../../Podfile.common'
+
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
@@ -6,6 +8,6 @@ platform :ios, '14.0'
 use_frameworks!
 
 target 'SLS_IMA-Player' do
-  pod 'Brightcove-Player-SSAI/XCFramework'
-  pod 'Brightcove-Player-IMA/XCFramework'
+  brightcove_pod 'Brightcove-Player-SSAI'
+  brightcove_pod 'Brightcove-Player-IMA'
 end

--- a/SSAI/SLS+IMA-tvOS/Podfile
+++ b/SSAI/SLS+IMA-tvOS/Podfile
@@ -1,3 +1,5 @@
+require_relative '../../Podfile.common'
+
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
@@ -6,6 +8,6 @@ platform :tvos, '14.0'
 use_frameworks!
 
 target 'SLS_IMA-Player' do
-  pod 'Brightcove-Player-SSAI/XCFramework'
-  pod 'Brightcove-Player-IMA/XCFramework'
+  brightcove_pod 'Brightcove-Player-SSAI'
+  brightcove_pod 'Brightcove-Player-IMA'
 end

--- a/SharePlay/Podfile
+++ b/SharePlay/Podfile
@@ -1,3 +1,5 @@
+require_relative '../Podfile.common'
+
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
@@ -6,5 +8,5 @@ platform :ios, '15.0'
 use_frameworks!
 
 target 'SharePlayPlayer' do
-  pod 'Brightcove-Player-Core/XCFramework'
+  brightcove_pod 'Brightcove-Player-Core'
 end

--- a/SidecarSubtitles/BasicSidecarSubtitlesPlayer-iOS/Podfile
+++ b/SidecarSubtitles/BasicSidecarSubtitlesPlayer-iOS/Podfile
@@ -1,3 +1,5 @@
+require_relative '../../Podfile.common'
+
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/brightcove/BrightcoveSpecs.git'
 
@@ -6,5 +8,5 @@ platform :ios, '12.0'
 use_frameworks!
 
 target 'BasicSidecarSubtitlesPlayer' do
-  pod 'Brightcove-Player-Core/XCFramework'
+  brightcove_pod 'Brightcove-Player-Core'
 end


### PR DESCRIPTION
## Summary

- Add `Podfile.common.rb` shared helper enabling seamless switching between published and local SDK builds
- Update all 31 CocoaPods-based sample Podfiles to use the new `brightcove_pod` helper
- Document the feature in README.md

## Motivation

Similar to the `anpVersion=LOCAL` feature in android-player-samples, this makes it easy to test samples against a local SDK build during development without manually editing Podfiles.

## Usage

```bash
# Use local SDK (default path: ../videocloud_agave)
BRIGHTCOVE_LOCAL_SDK=true pod install

# Use local SDK with custom path
BRIGHTCOVE_LOCAL_SDK=/path/to/sdk pod install

# Use published SDK (default, unchanged behavior)
pod install
```

## Key Features

- **Automatic pod name mapping**: `Brightcove-Player-Core` → `BCOVPlayerSDK`
- **Auto-injection of core dependency**: Plugin pods automatically include `BCOVPlayerSDK`
- **Clear console feedback**: Shows which mode is active and which local pods are used
- **Graceful errors**: Fails with clear message if local SDK path doesn't exist

## Test plan

- [x] Verify `pod install` (published mode) works unchanged
- [x] Verify `BRIGHTCOVE_LOCAL_SDK=true pod install` works with default path
- [x] Verify `BRIGHTCOVE_LOCAL_SDK=/custom/path pod install` works
- [x] Verify multi-pod samples (SSAI+IMA) work with auto core dependency injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)