### PR TITLE
fix: add cleanup in viewDidDisappear to prevent audio continuing after dismissal

### DIFF
--- a/DAI/BasicDAIPlayer-iOS/BasicDAIPlayer/BaseViewController.swift
+++ b/DAI/BasicDAIPlayer-iOS/BasicDAIPlayer/BaseViewController.swift
@@ -86,6 +86,17 @@ class BaseViewController: UIViewController {
         return statusBarHidden
     }
 
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+
+        // Clean up the playback controller to break retain cycles
+        // created by the IMA SDK (IMARemoteControl in IMA SDK 3.27.4+).
+        // This ensures proper deallocation and stops audio playback.
+        if isBeingDismissed || isMovingFromParent {
+            playerView?.playbackController = nil
+        }
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/IMA/BasicIMAPlayer-iOS/BasicIMAPlayer/BaseViewController.swift
+++ b/IMA/BasicIMAPlayer-iOS/BasicIMAPlayer/BaseViewController.swift
@@ -88,6 +88,17 @@ class BaseViewController: UIViewController {
         return statusBarHidden
     }
 
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+
+        // Clean up the playback controller to break retain cycles
+        // created by the IMA SDK (IMARemoteControl in IMA SDK 3.27.4+).
+        // This ensures proper deallocation and stops audio playback.
+        if isBeingDismissed || isMovingFromParent {
+            playerView?.playbackController = nil
+        }
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 


### PR DESCRIPTION
Companion of https://github.com/brightcove/videocloud_agave/pull/2585

## Summary

- Add `viewDidDisappear` cleanup to DAI and IMA sample apps to fix audio continuing after navigating away from the player

## Problem

IMA SDK 3.27.4 introduced a change where `IMARemoteControl` is instantiated when playback starts instead of during initialization. This creates a retain cycle that prevents proper deallocation of the view controller, causing audio to continue playing after navigating away from the player screen.

## Solution

Add `viewDidDisappear` that sets `playerView?.playbackController = nil` when the view controller is being dismissed. The `isBeingDismissed || isMovingFromParent` checks ensure cleanup only happens during actual dismissal, not during temporary situations like ad clickthrough modal presentations.

## Test plan

- [ ] Navigate to DAI player, start playback, navigate back - audio should stop
- [ ] Navigate to IMA player, start playback, navigate back - audio should stop  
- [ ] Click "Learn more" on an ad, close the webview - playback should resume normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)