### PR TITLE
fix: preserve AirPlay playback across navigation and backgrounding in SwiftUI sample

### DIFF
--- a/SwiftUI/SwiftUIPlayer-iOS/SwiftUIPlayer/Models/PlayerModel.swift
+++ b/SwiftUI/SwiftUIPlayer-iOS/SwiftUIPlayer/Models/PlayerModel.swift
@@ -18,11 +18,10 @@ final class PlayerModel: NSObject, ObservableObject {
     @Published
     var pictureInPictureEnabled = false
 
-    fileprivate(set) lazy var avpvc: AVPlayerViewController = {
-        let avpvc = AVPlayerViewController()
-        avpvc.delegate = self
-        return avpvc
-    }()
+    @Published
+    var isExternalPlaybackActive = false
+
+    private(set) var currentVideoId: String?
 
     fileprivate(set) lazy var playbackController: BCOVPlaybackController? = {
         let sdkManager = BCOVPlayerSDKManager.sharedManager()
@@ -39,8 +38,43 @@ final class PlayerModel: NSObject, ObservableObject {
         playbackController.delegate = self
         playbackController.isAutoAdvance = true
         playbackController.isAutoPlay = true
+        playbackController.allowsExternalPlayback = true
+        playbackController.allowsBackgroundAudioPlayback = true
 
         return playbackController
+    }()
+
+    fileprivate(set) lazy var avpvc: AVPlayerViewController = {
+        let avpvc = AVPlayerViewController()
+        avpvc.delegate = self
+        return avpvc
+    }()
+
+    fileprivate(set) lazy var bcovPlayerView: BCOVPUIPlayerView? = {
+        let options = BCOVPUIPlayerViewOptions()
+        options.automaticControlTypeSelection = true
+        options.showPictureInPictureButton = true
+
+        guard let playbackController else { return nil }
+
+        let playerView = BCOVPUIPlayerView(playbackController: playbackController,
+                                           options: options,
+                                           controlsView: nil)
+        playerView?.delegate = self
+
+        return playerView
+    }()
+
+    fileprivate(set) lazy var bcovPlayerViewController: BCOVPUIPlayerViewController = {
+        let options = BCOVPUIPlayerViewOptions()
+        options.automaticControlTypeSelection = true
+        options.showPictureInPictureButton = true
+
+        let vc = BCOVPUIPlayerViewController(playbackController: playbackController,
+                                             options: options,
+                                             controlsView: nil)
+        vc.delegate = self
+        return vc
     }()
 
 }
@@ -87,7 +121,15 @@ extension PlayerModel: BCOVPlaybackControllerDelegate {
             avpvc.player = player
         }
 
+        currentVideoId = session?.video?.properties[BCOVVideo.PropertyKeyId] as? String
+
         print("PlayerModel - Advanced to new session.")
+    }
+
+    func playbackController(_ controller: BCOVPlaybackController!,
+                            playbackSession session: BCOVPlaybackSession,
+                            didChangeExternalPlaybackActive externalPlaybackActive: Bool) {
+        isExternalPlaybackActive = externalPlaybackActive
     }
 
     func playbackController(_ controller: BCOVPlaybackController!,

--- a/SwiftUI/SwiftUIPlayer-iOS/SwiftUIPlayer/Views/BCOVPlayerUIView.swift
+++ b/SwiftUI/SwiftUIPlayer-iOS/SwiftUIPlayer/Views/BCOVPlayerUIView.swift
@@ -33,20 +33,11 @@ struct BCOVPlayerUIView: UIViewRepresentable {
     let playerModel: PlayerModel
 
     func makeUIView(context: Context) -> BCOVPUIPlayerView {
-        let options = BCOVPUIPlayerViewOptions()
-        options.automaticControlTypeSelection = true
-        options.showPictureInPictureButton = true
-
-        guard let playbackController = playerModel.playbackController,
-              let playerView = BCOVPUIPlayerView(playbackController: playbackController,
-                                                 options: options,
-                                                 controlsView: nil) else {
+        guard let playerView = playerModel.bcovPlayerView else {
             return BCOVPUIPlayerView()
         }
 
-        playbackController.options = [kBCOVAVPlayerViewControllerCompatibilityKey: false]
-
-        playerView.delegate = playerModel
+        playerModel.playbackController?.options = [kBCOVAVPlayerViewControllerCompatibilityKey: false]
 
         return playerView
     }

--- a/SwiftUI/SwiftUIPlayer-iOS/SwiftUIPlayer/Views/BCOVPlayerViewControllerRepresentable.swift
+++ b/SwiftUI/SwiftUIPlayer-iOS/SwiftUIPlayer/Views/BCOVPlayerViewControllerRepresentable.swift
@@ -36,23 +36,9 @@ struct BCOVPlayerViewControllerRepresentable: UIViewControllerRepresentable {
     let playerModel: PlayerModel
 
     func makeUIViewController(context: Context) -> BCOVPUIPlayerViewController {
-        let options = BCOVPUIPlayerViewOptions()
-        options.automaticControlTypeSelection = true
-        options.showPictureInPictureButton = true
+        playerModel.playbackController?.options = [kBCOVAVPlayerViewControllerCompatibilityKey: false]
 
-        guard let playbackController = playerModel.playbackController else {
-            return BCOVPUIPlayerViewController(playbackController: nil,
-                                               options: options,
-                                               controlsView: nil)
-        }
-
-        let playerViewController = BCOVPUIPlayerViewController(playbackController: playbackController,
-                                                               options: options,
-                                                               controlsView: nil)
-        
-        playbackController.options = [kBCOVAVPlayerViewControllerCompatibilityKey: false]
-        playerViewController.delegate = playerModel
-        return playerViewController
+        return playerModel.bcovPlayerViewController
     }
 
     func updateUIViewController(_ uiViewController: BCOVPUIPlayerViewController, context: Context) {

--- a/SwiftUI/SwiftUIPlayer-iOS/SwiftUIPlayer/Views/VideoDetailView.swift
+++ b/SwiftUI/SwiftUIPlayer-iOS/SwiftUIPlayer/Views/VideoDetailView.swift
@@ -46,7 +46,8 @@ struct VideoDetailView: View {
                 Button(action: {
                     if let playbackController = playerModel.playbackController,
                        !playerModel.fullscreenEnabled,
-                       !playerModel.pictureInPictureEnabled {
+                       !playerModel.pictureInPictureEnabled,
+                       !playerModel.isExternalPlaybackActive {
                         playbackController.setVideos(nil)
                     }
 
@@ -64,6 +65,13 @@ struct VideoDetailView: View {
         .onAppear {
             guard let playbackController = playerModel.playbackController else { return }
 
+            // Skip if this video is already playing on AirPlay
+            if playerModel.isExternalPlaybackActive &&
+               playerModel.currentVideoId == videoItem.id {
+                didSetVideo = true
+                return
+            }
+
             if !didSetVideo {
 #if targetEnvironment(simulator)
                 if videoItem.video.usesFairPlay {
@@ -72,7 +80,7 @@ struct VideoDetailView: View {
                 }
 #endif
                 playbackController.setVideos([videoItem.video])
-                didSetVideo.toggle()
+                didSetVideo = true
             }
         }
 #if targetEnvironment(simulator)


### PR DESCRIPTION
## Summary

Fixes AirPlay playback restarting from the beginning when users navigate away/back or background the app in the SwiftUI sample.

**Root causes:**
- Back button called `setVideos(nil)`, destroying the AVPlayer and its AirPlay connection
- `allowsBackgroundAudioPlayback` was not enabled, so the system paused the AVPlayer on background, disrupting the AirPlay session

**Changes:**
- Enable `allowsExternalPlayback` and `allowsBackgroundAudioPlayback` on the playback controller
- Track AirPlay state and current video ID on `PlayerModel` via the SDK's `didChangeExternalPlaybackActive` delegate callback
- Skip `setVideos(nil)` on back navigation when AirPlay is active (preserve the session)
- Skip re-loading the video on `onAppear` if AirPlay is already playing it (same video returns seamlessly)
- Make `BCOVPUIPlayerView` and `BCOVPUIPlayerViewController` persistent lazy vars on `PlayerModel`, matching the existing `AVPlayerViewController` singleton pattern — prevents SwiftUI navigation teardown from destroying the player views

## Test plan

- [x] AVPlayerViewController mode: AirPlay → navigate back → same video → playback continues
- [x] AVPlayerViewController mode: AirPlay → lock screen → unlock → playback continues
- [x] AVPlayerViewController mode: AirPlay → background → foreground → playback continues
- [x] AVPlayerViewController mode: AirPlay → navigate back → different video → new video plays on AirPlay
- [x] BCOV View mode: same navigation/background tests
- [x] BCOV ViewController mode: same navigation/background tests
- [x] Without AirPlay: back button still clears video (normal behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)