### PR TITLE
BC-68911: Opt DAI samples into automatic session recovery

### DIFF
--- a/DAI/BasicDAIPlayer-iOS/BasicDAIPlayer/AssetKeyViewController.swift
+++ b/DAI/BasicDAIPlayer-iOS/BasicDAIPlayer/AssetKeyViewController.swift
@@ -27,7 +27,13 @@ final class AssetKeyViewController: BaseViewController {
 
         // BCOVDAIPlaybackSessionDelegate defines -willCallIMAAdsLoaderRequestAdsWithRequest:
         // which allows us to modify the IMAStreamRequest object before it is used to load ads.
-        let daiPlaybackSessionOptions = [ kBCOVDAIOptionDAIPlaybackSessionDelegateKey: self ]
+        // kBCOVDAIOptionAutomaticRecoveryEnabledKey opts in to automatic DAI session
+        // recovery (on by default; see BCOVDAIComponent.h). Particularly relevant for
+        // Live DAI streams, where stitched ad URLs have a short TTL.
+        let daiPlaybackSessionOptions: [String: Any] = [
+            kBCOVDAIOptionDAIPlaybackSessionDelegateKey: self,
+            kBCOVDAIOptionAutomaticRecoveryEnabledKey: true
+        ]
 
         let daiSessionProvider = sdkManager.createDAISessionProvider(with: imaSettings,
                                                                      adsRenderingSettings: adsRenderingSettings,

--- a/DAI/BasicDAIPlayer-iOS/BasicDAIPlayer/VideoPropertiesViewController.swift
+++ b/DAI/BasicDAIPlayer-iOS/BasicDAIPlayer/VideoPropertiesViewController.swift
@@ -27,7 +27,12 @@ final class VideoPropertiesViewController: BaseViewController {
 
         // BCOVDAIPlaybackSessionDelegate defines -willCallIMAAdsLoaderRequestAdsWithRequest:
         // which allows us to modify the IMAStreamRequest object before it is used to load ads.
-        let daiPlaybackSessionOptions = [ kBCOVDAIOptionDAIPlaybackSessionDelegateKey: self ]
+        // kBCOVDAIOptionAutomaticRecoveryEnabledKey opts in to automatic DAI session
+        // recovery (on by default; see BCOVDAIComponent.h).
+        let daiPlaybackSessionOptions: [String: Any] = [
+            kBCOVDAIOptionDAIPlaybackSessionDelegateKey: self,
+            kBCOVDAIOptionAutomaticRecoveryEnabledKey: true
+        ]
 
         let daiSessionProvider = sdkManager.createDAISessionProvider(with: imaSettings,
                                                                      adsRenderingSettings: adsRenderingSettings,

--- a/DAI/BasicDAIPlayer-tvOS/BasicDAIPlayer/ViewController.swift
+++ b/DAI/BasicDAIPlayer-tvOS/BasicDAIPlayer/ViewController.swift
@@ -61,13 +61,20 @@ final class ViewController: UIViewController {
 
         let adsRequestPolicy = BCOVDAIAdsRequestPolicy.videoProperties();
 
+        // Opt in to automatic DAI session recovery (on by default; see
+        // `kBCOVDAIOptionAutomaticRecoveryEnabledKey` in BCOVDAIComponent.h).
+        let daiOptions: [String: Any] = [
+            kBCOVDAIOptionAutomaticRecoveryEnabledKey: true
+        ]
+
         let daiSessionProvider = sdkManager.createDAISessionProvider(with: imaSettings,
                                                                      adsRenderingSettings: adsRenderingSettings,
                                                                      adsRequestPolicy: adsRequestPolicy,
                                                                      adContainer: playerView!.contentOverlayView,
                                                                      viewController: self,
                                                                      companionSlots: nil,
-                                                                     upstreamSessionProvider: fps)
+                                                                     upstreamSessionProvider: fps,
+                                                                     options: daiOptions)
 
         guard let playerView else {
             return nil


### PR DESCRIPTION
## Summary

Threads the new `kBCOVDAIOptionAutomaticRecoveryEnabledKey` option through the three BasicDAIPlayer view controllers (tvOS, iOS VideoProperties, iOS AssetKey). The SDK defaults this to YES, but making the opt-in explicit here surfaces the option site to anyone reading the samples.

## Context

Companion to the SDK change that fixes BC-68911 (black screen after long Apple TV sleep during a DAI ad). The SDK does all the heavy lifting (terminal-event detection, media-services-reset, long-background foreground trigger, NWPathMonitor gating, IMA + AVPlayer rebuild, controller reload). The samples just demonstrate the option.

SDK PR: https://github.com/brightcove/videocloud_agave/pull/2603

## Changes

- `BasicDAIPlayer-tvOS/ViewController.swift`: switched to the `options:`-taking overload of `createDAISessionProvider`, adding the recovery key.
- `BasicDAIPlayer-iOS/VideoPropertiesViewController.swift`: added the key to the existing delegate-options dict.
- `BasicDAIPlayer-iOS/AssetKeyViewController.swift`: same, with a comment noting Live DAI relevance (stitched URL TTL).

## Test plan

- [ ] Samples build against 7.2.8 (the SDK release that will carry this fix)
- [ ] tvOS sample reproduces BC-68911 recovery path: background ≥60s during ad, foreground → clean recovery