### PR TITLE
feat(swiftui-ima): enable IMASettings.enableBackgroundPlayback for PiP + AirPlay

### DIFF
--- a/SwiftUI/SwiftUIPlayerIMA-iOS/SwiftUIPlayerIMA/Views/IMAPlayerViewController.swift
+++ b/SwiftUI/SwiftUIPlayerIMA-iOS/SwiftUIPlayerIMA/Views/IMAPlayerViewController.swift
@@ -116,6 +116,15 @@ final class IMAPlayerViewController: BCOVPUIPlayerViewController {
 
         let imaSettings = IMASettings()
         imaSettings.language = Locale.current.language.languageCode?.identifier ?? "en"
+        // Render ads through the content `AVPlayer` (via `IMAAVPlayerVideoDisplay`)
+        // rather than IMA's own internal ad player. Required for PiP and AirPlay
+        // continuity across ads: PiP is bound to the content `AVPlayerLayer`, so
+        // unless ads render into that same player the PiP overlay shows the paused
+        // content frame during an ad and PiP controls keep operating on content
+        // (scrub past the ad, etc.). With this on, `BCOVIMASession` wires up an
+        // `IMAPictureInPictureProxy` so the PiP controller's delegate callbacks
+        // are mediated through IMA.
+        imaSettings.enableBackgroundPlayback = true
 
         let renderSettings = IMAAdsRenderingSettings()
         renderSettings.linkOpenerPresentingController = self


### PR DESCRIPTION
## Summary

- Sets `imaSettings.enableBackgroundPlayback = true` in `IMAPlayerViewController.makePlaybackController()`. This switches IMA to render ads through the **same** content `AVPlayer` (via `IMAAVPlayerVideoDisplay`) instead of its own internal ad player.
- Why: PiP is bound to the content `AVPlayerLayer`. In the default mode IMA's ad lives on a sibling player, so PiP shows the paused content frame for the duration of an ad and the PiP scrubber operates on content — letting the viewer scrub past the ad. With this flag on, ads render through the same player PiP wraps, and the Brightcove IMA plugin's `IMAPictureInPictureProxy` mediates the PiP controller's delegate callbacks.
- Pairs with the SDK fixes landing in the SDK v7.2.12, which take care of the inline ad-rendering and PiP-scrubber behavior in this shared-player mode.

## Notes

Play/pause from the PiP overlay during ads is still possible. iOS exposes no API to hide that control, and IAB SRG explicitly permits user-initiated pause on ads. This is documented in the 7.2.12 SDK CHANGELOG note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)