### PR TITLE
fix: repair broken Assets.xcassets symlinks across samples

### DIFF
--- a/DAI/BasicDAIPlayer-iOS/BasicDAIPlayer/Assets.xcassets
+++ b/DAI/BasicDAIPlayer-iOS/BasicDAIPlayer/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets

--- a/DAI/BasicDAIPlayer-tvOS/BasicDAIPlayer/Assets.xcassets
+++ b/DAI/BasicDAIPlayer-tvOS/BasicDAIPlayer/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets

--- a/Freewheel/BasicFreeWheelPlayer-iOS/BasicFreeWheelPlayer/Assets.xcassets
+++ b/Freewheel/BasicFreeWheelPlayer-iOS/BasicFreeWheelPlayer/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets

--- a/GoogleCast/BasicCastPlayer/BasicCastPlayer/Assets.xcassets
+++ b/GoogleCast/BasicCastPlayer/BasicCastPlayer/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets

--- a/GoogleCast/BrightcoveCastReceiver/BrightcoveCastReceiver/Assets.xcassets
+++ b/GoogleCast/BrightcoveCastReceiver/BrightcoveCastReceiver/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets

--- a/IMA/BasicIMAPlayer-iOS/BasicIMAPlayer/Assets.xcassets
+++ b/IMA/BasicIMAPlayer-iOS/BasicIMAPlayer/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets

--- a/IMA/NativeControlsIMAPlayer-tvOS/NativeControlsIMAPlayer/Assets.xcassets
+++ b/IMA/NativeControlsIMAPlayer-tvOS/NativeControlsIMAPlayer/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets

--- a/Offline/OfflinePlayer/OfflinePlayer/Assets.xcassets
+++ b/Offline/OfflinePlayer/OfflinePlayer/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets

--- a/Omniture/BasicOmniturePlayer/BasicOmniturePlayer/Assets.xcassets
+++ b/Omniture/BasicOmniturePlayer/BasicOmniturePlayer/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets

--- a/Player/AppleTV/AppleTV/Assets.xcassets
+++ b/Player/AppleTV/AppleTV/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets

--- a/Player/CustomControls/CustomControls/Assets.xcassets
+++ b/Player/CustomControls/CustomControls/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets

--- a/Player/DVRLive/DVRLive/Assets.xcassets
+++ b/Player/DVRLive/DVRLive/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets

--- a/Player/NativeControls/NativeControls/Assets.xcassets
+++ b/Player/NativeControls/NativeControls/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets

--- a/Player/SubtitleRendering/SubtitleRendering/Assets.xcassets
+++ b/Player/SubtitleRendering/SubtitleRendering/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets

--- a/Player/TableViewPlayer/TableViewPlayer/Assets.xcassets
+++ b/Player/TableViewPlayer/TableViewPlayer/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets

--- a/Player/VerticalPlayer/VerticalPlayer/Assets.xcassets
+++ b/Player/VerticalPlayer/VerticalPlayer/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets

--- a/Player/Video360/Video360Player/Assets.xcassets
+++ b/Player/Video360/Video360Player/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets

--- a/Player/VideoCloudBasicPlayer/VideoCloudBasicPlayer/Assets.xcassets
+++ b/Player/VideoCloudBasicPlayer/VideoCloudBasicPlayer/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets

--- a/Player/VideoPreloading/VideoPreloading/Assets.xcassets
+++ b/Player/VideoPreloading/VideoPreloading/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets

--- a/PlayerUI/Flutter/FlutterPlayer/Assets.xcassets
+++ b/PlayerUI/Flutter/FlutterPlayer/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets

--- a/PlayerUI/PlayerUICustomization/PlayerUICustomization/Assets.xcassets
+++ b/PlayerUI/PlayerUICustomization/PlayerUICustomization/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets

--- a/PlayerUI/ReactNative/ios/ReactNativePlayer/Assets.xcassets
+++ b/PlayerUI/ReactNative/ios/ReactNativePlayer/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets

--- a/PlayerUI/ViewStrategy/ViewStrategy/Assets.xcassets
+++ b/PlayerUI/ViewStrategy/ViewStrategy/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets

--- a/Pulse/BasicPulsePlayer-iOS/BasicPulsePlayer/Assets.xcassets
+++ b/Pulse/BasicPulsePlayer-iOS/BasicPulsePlayer/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets

--- a/Pulse/BasicPulsePlayer-tvOS/BasicPulsePlayer/Assets.xcassets
+++ b/Pulse/BasicPulsePlayer-tvOS/BasicPulsePlayer/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets

--- a/SSAI/BasicSSAIPlayer-iOS/BasicSSAIPlayer/Assets.xcassets
+++ b/SSAI/BasicSSAIPlayer-iOS/BasicSSAIPlayer/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets

--- a/SSAI/BasicSSAIPlayer-tvOS/BasicSSAIPlayer/Assets.xcassets
+++ b/SSAI/BasicSSAIPlayer-tvOS/BasicSSAIPlayer/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets

--- a/SSAI/SLS+IMA-iOS/SLS_IMA-Player/Assets.xcassets
+++ b/SSAI/SLS+IMA-iOS/SLS_IMA-Player/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets

--- a/SSAI/SLS+IMA-tvOS/SLS_IMA-Player/Assets.xcassets
+++ b/SSAI/SLS+IMA-tvOS/SLS_IMA-Player/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets

--- a/SharePlay/SharePlayPlayer/Assets.xcassets
+++ b/SharePlay/SharePlayPlayer/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets

--- a/SidecarSubtitles/BasicSidecarSubtitlesPlayer-iOS/BasicSidecarSubtitlesPlayer/Assets.xcassets
+++ b/SidecarSubtitles/BasicSidecarSubtitlesPlayer-iOS/BasicSidecarSubtitlesPlayer/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets

--- a/SwiftUI/CustomControls-iOS/CustomControls/Assets.xcassets
+++ b/SwiftUI/CustomControls-iOS/CustomControls/Assets.xcassets
@@ -1,1 +1,1 @@
-../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets
+../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets


### PR DESCRIPTION
## Summary

Most samples in this repo share a single `Assets.xcassets` by symlinking into the FairPlay sample. 32 of those symlinks were dangling: they pointed into a nonexistent `swift/` subdirectory (`FairPlay/BasicFairPlayPlayer-iOS/swift/...`), and several also used the wrong number of `../` levels (overshooting past the repo root). Xcode tolerated this because each `project.pbxproj` references the real catalog by its group-relative `path`, so local builds kept working and the broken links stayed invisible. Anyone consuming a sample standalone (extracting it out of the monorepo) hit `Failed to read file attributes ...` build failures instead.

This repoints every broken symlink at the real catalog (`FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`) with the correct relative depth, matching the one sample that was already correct (`SwiftUI/SwiftUIPlayer-iOS`). All 32 now resolve, and the shared-asset convention is preserved (no `.pbxproj` files were touched).

## Symlinks fixed (32)

- `DAI/BasicDAIPlayer-iOS/BasicDAIPlayer/Assets.xcassets`
  - old: `../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`
- `DAI/BasicDAIPlayer-tvOS/BasicDAIPlayer/Assets.xcassets`
  - old: `../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`
- `Freewheel/BasicFreeWheelPlayer-iOS/BasicFreeWheelPlayer/Assets.xcassets`
  - old: `../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`
- `GoogleCast/BasicCastPlayer/BasicCastPlayer/Assets.xcassets`
  - old: `../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`
- `GoogleCast/BrightcoveCastReceiver/BrightcoveCastReceiver/Assets.xcassets`
  - old: `../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`
- `IMA/BasicIMAPlayer-iOS/BasicIMAPlayer/Assets.xcassets`
  - old: `../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`
- `IMA/NativeControlsIMAPlayer-tvOS/NativeControlsIMAPlayer/Assets.xcassets`
  - old: `../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`
- `Offline/OfflinePlayer/OfflinePlayer/Assets.xcassets`
  - old: `../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`
- `Omniture/BasicOmniturePlayer/BasicOmniturePlayer/Assets.xcassets`
  - old: `../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`
- `Player/AppleTV/AppleTV/Assets.xcassets`
  - old: `../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`
- `Player/CustomControls/CustomControls/Assets.xcassets`
  - old: `../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`
- `Player/DVRLive/DVRLive/Assets.xcassets`
  - old: `../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`
- `Player/NativeControls/NativeControls/Assets.xcassets`
  - old: `../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`
- `Player/SubtitleRendering/SubtitleRendering/Assets.xcassets`
  - old: `../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`
- `Player/TableViewPlayer/TableViewPlayer/Assets.xcassets`
  - old: `../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`
- `Player/VerticalPlayer/VerticalPlayer/Assets.xcassets`
  - old: `../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`
- `Player/Video360/Video360Player/Assets.xcassets`
  - old: `../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`
- `Player/VideoCloudBasicPlayer/VideoCloudBasicPlayer/Assets.xcassets`
  - old: `../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`
- `Player/VideoPreloading/VideoPreloading/Assets.xcassets`
  - old: `../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`
- `PlayerUI/Flutter/FlutterPlayer/Assets.xcassets`
  - old: `../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`
- `PlayerUI/PlayerUICustomization/PlayerUICustomization/Assets.xcassets`
  - old: `../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`
- `PlayerUI/ReactNative/ios/ReactNativePlayer/Assets.xcassets`
  - old: `../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`
- `PlayerUI/ViewStrategy/ViewStrategy/Assets.xcassets`
  - old: `../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`
- `Pulse/BasicPulsePlayer-iOS/BasicPulsePlayer/Assets.xcassets`
  - old: `../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`
- `Pulse/BasicPulsePlayer-tvOS/BasicPulsePlayer/Assets.xcassets`
  - old: `../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`
- `SSAI/BasicSSAIPlayer-iOS/BasicSSAIPlayer/Assets.xcassets`
  - old: `../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`
- `SSAI/BasicSSAIPlayer-tvOS/BasicSSAIPlayer/Assets.xcassets`
  - old: `../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`
- `SSAI/SLS+IMA-iOS/SLS_IMA-Player/Assets.xcassets`
  - old: `../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`
- `SSAI/SLS+IMA-tvOS/SLS_IMA-Player/Assets.xcassets`
  - old: `../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`
- `SharePlay/SharePlayPlayer/Assets.xcassets`
  - old: `../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`
- `SidecarSubtitles/BasicSidecarSubtitlesPlayer-iOS/BasicSidecarSubtitlesPlayer/Assets.xcassets`
  - old: `../../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`
- `SwiftUI/CustomControls-iOS/CustomControls/Assets.xcassets`
  - old: `../../../FairPlay/BasicFairPlayPlayer-iOS/swift/BasicFairPlayPlayer/Assets.xcassets`
  - new: `../../../FairPlay/BasicFairPlayPlayer-iOS/BasicFairPlayPlayer/Assets.xcassets`

## Verification

- Re-ran the broken-symlink sweep (`find . -type l -exec test ! -e {} \; -print`): zero broken symlinks remain.
- Confirmed all 33 `Assets.xcassets` entries stay mode `120000` (symlinks), none converted to real files.
- Compiled an affected sample's catalog through the repointed symlink with `actool` (DAI/BasicDAIPlayer-iOS): exit 0, no file-attribute errors (this is the phase that failed before).
- A full `xcodebuild` of the sample was attempted but blocked by an unrelated SDK module-resolution issue in this environment (BrightcoveDAI / GoogleInteractiveMediaAds frameworks not resolving). Since no `.pbxproj` group-relative paths were changed, local builds cannot regress from this change.
