### PR TITLE
chore: drop /XCFramework subspec from brightcove_pod helper

### DIFF
--- a/Podfile.common.rb
+++ b/Podfile.common.rb
@@ -71,13 +71,12 @@ end
 # Helper to declare a Brightcove pod with automatic local/published switching
 #
 # @param name [String] The published pod name (e.g., 'Brightcove-Player-Core')
-# @param subspec [String] The subspec to use for published pods (default: '/XCFramework')
 #
 # Examples:
 #   brightcove_pod 'Brightcove-Player-Core'
 #   brightcove_pod 'Brightcove-Player-IMA'
 #
-def brightcove_pod(name, subspec: '/XCFramework')
+def brightcove_pod(name)
   local_sdk_path = brightcove_local_sdk_path
 
   if local_sdk_path
@@ -95,7 +94,7 @@ def brightcove_pod(name, subspec: '/XCFramework')
 
     _register_local_brightcove_pod(name, local_sdk_path)
   else
-    pod "#{name}#{subspec}"
+    pod name
   end
 end
 


### PR DESCRIPTION
## Summary

`brightcove_pod` previously appended `/XCFramework` to every published pod name (`pod 'Brightcove-Player-IMA/XCFramework'`). As of the Brightcove Player SDK 7.2.13, the public podspecs no longer expose a `Framework` / `XCFramework` subspec pair — the XCFramework configuration is inlined at the top of each podspec. With that change, `pod 'Brightcove-Player-X/XCFramework'` no longer resolves, and the helper has to pass the pod name through unchanged.

This patch:
- Removes the `subspec:` keyword argument from `brightcove_pod`.
- Calls `pod name` instead of `pod "#{name}#{subspec}"`.

The `BRIGHTCOVE_LOCAL_SDK` switching logic is unchanged; local-pod resolution via `:path =>` still works.

No individual sample Podfile is affected — all 32 use the helper rather than spelling out the subspec directly.

## Test plan

- [x] `ruby -c Podfile.common.rb` passes.
- [x] `pod install` clean in one representative sample per domain against SDK 7.2.13:
  - Player (`Player/VideoCloudBasicPlayer`), IMA (`IMA/BasicIMAPlayer-iOS`), SSAI (`SSAI/BasicSSAIPlayer-tvOS`), DAI (`DAI/BasicDAIPlayer-iOS`), FairPlay (`FairPlay/BasicFairPlayPlayer-iOS`), FreeWheel (`Freewheel/BasicFreeWheelPlayer-iOS`), Pulse (`Pulse/BasicPulsePlayer-iOS`), Omniture (`Omniture/BasicOmniturePlayer`), GoogleCast (`GoogleCast/BasicCastPlayer`). All resolve `Brightcove-Player-Core (7.2.13)` and the relevant plugin at 7.2.13.
  - `BasicIMAPlayer` (iOS) and `BasicSSAIPlayer` (tvOS) additionally built end-to-end with `xcodebuild` against simulator; built `.app` bundles embed `BrightcovePlayerSDK.framework` and the plugin framework with `CFBundleShortVersionString = 7.2.13`.
- [x] `BRIGHTCOVE_LOCAL_SDK=true pod install` clean against a local `videocloud_agave` checkout (validated on `Player/VideoCloudBasicPlayer`): `Brightcove SDK: Using LOCAL build from ../videocloud_agave` and `Installing BCOVPlayerSDK (7.2.13)` confirm the local-pod resolution path still works after the helper change.

## Pairing

Pairs with the SDK 7.2.13 release that drops the `/Framework` and `/XCFramework` subspecs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)