### PR TITLE
Clean up and modernize the sample app code

### DIFF
--- a/Analytics/BasicOmniturePlayer/AppDelegate.swift
+++ b/Analytics/BasicOmniturePlayer/AppDelegate.swift
@@ -9,7 +9,7 @@ import AVFoundation
 import UIKit
 
 
-@UIApplicationMain
+@main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/Analytics/BasicOmniturePlayer/ViewController.swift
+++ b/Analytics/BasicOmniturePlayer/ViewController.swift
@@ -111,7 +111,7 @@ final class ViewController: UIViewController {
             // You can set video length to 0. Omniture plugin will update it later for you.
             let settings = ADBMobile.mediaCreateSettings(withName: "BCOVOmniturePlayerMediaSettings",
                                                          length: 0,
-                                                         playerName: "BasicOmmiturePlayer",
+                                                         playerName: "BasicOmniturePlayer",
                                                          playerID: "BasicOmniturePlayer")
 
             // Adobe media analytics setting customization
@@ -126,14 +126,14 @@ final class ViewController: UIViewController {
                                                              delegate: self)
     }()
 
-    fileprivate lazy var statusBarHidden = false {
+    fileprivate var statusBarHidden = false {
         didSet {
             setNeedsStatusBarAppearanceUpdate()
         }
     }
 
     override var prefersStatusBarHidden: Bool {
-        return statusBarHidden
+        statusBarHidden
     }
 
     override func viewDidLoad() {
@@ -193,16 +193,11 @@ final class ViewController: UIViewController {
 extension ViewController: BCOVPlaybackControllerDelegate {
 
     func playbackController(_ controller: BCOVPlaybackController!,
-                            didAdvanceTo session: BCOVPlaybackSession!) {
-        print("ViewController - Advanced to new session.")
-    }
-
-    func playbackController(_ controller: BCOVPlaybackController!,
                             playbackSession session: BCOVPlaybackSession,
                             didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {
 
         if kBCOVPlaybackSessionLifecycleEventFail == lifecycleEvent.eventType,
-           let error = lifecycleEvent.properties["error"] as? NSError {
+           let error = lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError] as? NSError {
             // Report any errors that may have occurred with playback.
             print("ViewController - Playback error: \(error.localizedDescription)")
         }

--- a/Captions/BasicSidecarSubtitlesPlayer/BasicSidecarSubtitlesPlayer/AppDelegate.swift
+++ b/Captions/BasicSidecarSubtitlesPlayer/BasicSidecarSubtitlesPlayer/AppDelegate.swift
@@ -9,7 +9,7 @@ import AVFoundation
 import UIKit
 
 
-@UIApplicationMain
+@main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/Captions/BasicSidecarSubtitlesPlayer/BasicSidecarSubtitlesPlayer/ViewController.swift
+++ b/Captions/BasicSidecarSubtitlesPlayer/BasicSidecarSubtitlesPlayer/ViewController.swift
@@ -19,7 +19,7 @@
  *
  * `-textTracks` creates the array of subtitle dictionaries.
  * When creating these dictionaries, be sure to make note of which fields
- * are required are optional as specified in BCOVSSComponent.h.
+ * are required or optional as specified in BCOVSSComponent.h.
  *
  * Note that in this sample the subtitle track does not match the audio of the
  * video; it's only used as an example.
@@ -126,14 +126,14 @@ final class ViewController: UIViewController {
         ]
     }()
 
-    fileprivate lazy var statusBarHidden = false {
+    fileprivate var statusBarHidden = false {
         didSet {
             setNeedsStatusBarAppearanceUpdate()
         }
     }
 
     override var prefersStatusBarHidden: Bool {
-        return statusBarHidden
+        statusBarHidden
     }
 
     override func viewDidLoad() {
@@ -211,16 +211,11 @@ final class ViewController: UIViewController {
 extension ViewController: BCOVPlaybackControllerDelegate {
 
     func playbackController(_ controller: BCOVPlaybackController!,
-                            didAdvanceTo session: BCOVPlaybackSession!) {
-        print("ViewController - Advanced to new session.")
-    }
-
-    func playbackController(_ controller: BCOVPlaybackController!,
                             playbackSession session: BCOVPlaybackSession,
                             didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {
 
         if kBCOVPlaybackSessionLifecycleEventFail == lifecycleEvent.eventType,
-           let error = lifecycleEvent.properties["error"] as? NSError {
+           let error = lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError] as? NSError {
             // Report any errors that may have occurred with playback.
             print("ViewController - Playback error: \(error.localizedDescription)")
         }

--- a/Captions/SubtitleRendering/SubtitleRendering/AppDelegate.swift
+++ b/Captions/SubtitleRendering/SubtitleRendering/AppDelegate.swift
@@ -9,7 +9,7 @@ import AVFoundation
 import UIKit
 
 
-@UIApplicationMain
+@main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/Captions/SubtitleRendering/SubtitleRendering/SubtitleManager.swift
+++ b/Captions/SubtitleRendering/SubtitleRendering/SubtitleManager.swift
@@ -40,7 +40,7 @@ final class SubtitleManager {
     }
 
     fileprivate func parseSubtitle(with subtitleString: String) {
-        subtitles = .init()
+        var parsed: [Subtitle] = .init()
 
         let lines = subtitleString.components(separatedBy: "\n")
         for line in lines {
@@ -51,7 +51,7 @@ final class SubtitleManager {
                                                     options: .caseInsensitive)
                 let matches = regex.matches(in: line,
                                             options: NSRegularExpression.MatchingOptions(rawValue: 0),
-                                            range: NSRange(location: 0, length: line.count))
+                                            range: NSRange(location: 0, length: (line as NSString).length))
 
                 if matches.count == 1 {
                     if let result = matches.first {
@@ -74,22 +74,22 @@ final class SubtitleManager {
                             break
                         }
 
-                        let startTime = (startTimeMinute * 60.0 * 60.0) + (startTimeSecond * 60) + (startTimeMS / 1000)
-                        let endTime = (endTimeMinute * 60.0 * 60.0) + (endTimeSecond * 60) + (endTimeMS / 1000)
+                        let startTime = (startTimeMinute * 60.0) + startTimeSecond + (startTimeMS / 1000.0)
+                        let endTime = (endTimeMinute * 60.0) + endTimeSecond + (endTimeMS / 1000.0)
 
                         // Create a new instance and assign the time range
                         let subtitle = Subtitle()
-                        subtitle.startTime = CMTimeMake(value: Int64(startTime),
-                                                                timescale: 60)
-                        subtitle.endTime = CMTimeMake(value: Int64(endTime),
-                                                              timescale: 60)
+                        subtitle.startTime = CMTime(seconds: startTime,
+                                                    preferredTimescale: 1000)
+                        subtitle.endTime = CMTime(seconds: endTime,
+                                                  preferredTimescale: 1000)
 
-                        subtitles.append(subtitle)
+                        parsed.append(subtitle)
                     }
                 }
 
                 if matches.count == 0 && !line.isEmpty {
-                    if let currentSubtitle = subtitles.last {
+                    if let currentSubtitle = parsed.last {
                         if let text = currentSubtitle.text {
                             currentSubtitle.text = text.appending(" \(line)")
                         } else {
@@ -101,6 +101,10 @@ final class SubtitleManager {
                 print("Error creating regex")
                 break
             }
+        }
+
+        DispatchQueue.main.async {
+            self.subtitles = parsed
         }
     }
 

--- a/Captions/SubtitleRendering/SubtitleRendering/SubtitleManager.swift
+++ b/Captions/SubtitleRendering/SubtitleRendering/SubtitleManager.swift
@@ -18,18 +18,19 @@ final class Subtitle {
 
 final class SubtitleManager {
 
-    fileprivate lazy var subtitles: [Subtitle] = .init()
+    fileprivate var subtitles: [Subtitle] = .init()
 
     init(subtitleURL: URL) {
         URLSession.shared.dataTask(with: URLRequest(url: subtitleURL)) {
-            [self] (data: Data?, response: URLResponse?, error: Error?) in
+            [weak self] (data: Data?, response: URLResponse?, error: Error?) in
 
             if let error {
                 print("SubtitleManager encountered error: \(error.localizedDescription)")
                 return
             }
 
-            guard let data,
+            guard let self,
+                  let data,
                   let subtitleString = String(data: data, encoding: .utf8) else {
                 return
             }
@@ -50,7 +51,7 @@ final class SubtitleManager {
                                                     options: .caseInsensitive)
                 let matches = regex.matches(in: line,
                                             options: NSRegularExpression.MatchingOptions(rawValue: 0),
-                                            range: NSMakeRange(0, line.count))
+                                            range: NSRange(location: 0, length: line.count))
 
                 if matches.count == 1 {
                     if let result = matches.first {

--- a/Captions/SubtitleRendering/SubtitleRendering/ViewController.swift
+++ b/Captions/SubtitleRendering/SubtitleRendering/ViewController.swift
@@ -82,17 +82,17 @@ final class ViewController: UIViewController {
         return playbackController
     }()
 
-    fileprivate lazy var textTracks: [[String: Any]]? = .init()
+    fileprivate var textTracks: [[String: Any]]? = .init()
     fileprivate var subtitleManager: SubtitleManager?
 
-    fileprivate lazy var statusBarHidden = false {
+    fileprivate var statusBarHidden = false {
         didSet {
             setNeedsStatusBarAppearanceUpdate()
         }
     }
 
     override var prefersStatusBarHidden: Bool {
-        return statusBarHidden
+        statusBarHidden
     }
 
     override func viewDidLoad() {
@@ -175,8 +175,8 @@ final class ViewController: UIViewController {
 
         // Now update the BCOVVideo with our new text tracks array
         let updatedVideo = video.update { [self] (mutableVideo: BCOVMutableVideo) in
-            if let textTracks{
-               var props = mutableVideo.properties
+            if let textTracks {
+                var props = mutableVideo.properties
                 props["text_tracks"] = textTracks
                 mutableVideo.properties = props
             }
@@ -223,9 +223,7 @@ extension ViewController: BCOVPlaybackControllerDelegate {
 
     func playbackController(_ controller: BCOVPlaybackController!,
                             didAdvanceTo session: BCOVPlaybackSession!) {
-        print("ViewController - Advanced to new session.")
-
-        if (UIAccessibility.isClosedCaptioningEnabled) {
+        if UIAccessibility.isClosedCaptioningEnabled {
             print("WARNING: Closed Captions + SDH is enabled in the device Accessibility settings.")
             print("         A text track might be forcibly rendered in the video view.")
         }
@@ -245,7 +243,7 @@ extension ViewController: BCOVPlaybackControllerDelegate {
                             didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {
 
         if kBCOVPlaybackSessionLifecycleEventFail == lifecycleEvent.eventType,
-           let error = lifecycleEvent.properties["error"] as? NSError {
+           let error = lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError] as? NSError {
             // Report any errors that may have occurred with playback.
             print("ViewController - Playback error: \(error.localizedDescription)")
         }
@@ -264,7 +262,7 @@ extension ViewController: BCOVPUIPlayerViewDelegate {
 }
 
 
-// MARK: UITableViewDelegate
+// MARK: - UITableViewDelegate
 
 extension ViewController: UITableViewDelegate {
 
@@ -283,7 +281,7 @@ extension ViewController: UITableViewDelegate {
     }
 }
 
-// MARK: UITableViewDataSource
+// MARK: - UITableViewDataSource
 
 extension ViewController: UITableViewDataSource {
 

--- a/Captions/SubtitleRendering/SubtitleRendering/ViewController.swift
+++ b/Captions/SubtitleRendering/SubtitleRendering/ViewController.swift
@@ -85,6 +85,9 @@ final class ViewController: UIViewController {
     fileprivate var textTracks: [[String: Any]]? = .init()
     fileprivate var subtitleManager: SubtitleManager?
 
+    fileprivate var timeObserverToken: Any?
+    fileprivate weak var observedPlayer: AVPlayer?
+
     fileprivate var statusBarHidden = false {
         didSet {
             setNeedsStatusBarAppearanceUpdate()
@@ -93,6 +96,12 @@ final class ViewController: UIViewController {
 
     override var prefersStatusBarHidden: Bool {
         statusBarHidden
+    }
+
+    deinit {
+        if let token = timeObserverToken {
+            observedPlayer?.removeTimeObserver(token)
+        }
     }
 
     override func viewDidLoad() {
@@ -228,14 +237,20 @@ extension ViewController: BCOVPlaybackControllerDelegate {
             print("         A text track might be forcibly rendered in the video view.")
         }
 
-        session.player?.addPeriodicTimeObserver(forInterval: CMTimeMake(value: 1, timescale: 60),
-                                                queue: DispatchQueue.main) {
-            [self] (time: CMTime) in
+        if let token = timeObserverToken {
+            observedPlayer?.removeTimeObserver(token)
+        }
 
-            if let subtitle = subtitleManager?.subtitleForTime(time) {
-                subtitlesLabel.text = subtitle
+        timeObserverToken = session.player?.addPeriodicTimeObserver(forInterval: CMTimeMake(value: 1, timescale: 60),
+                                                                    queue: DispatchQueue.main) {
+            [weak self] (time: CMTime) in
+            guard let self else { return }
+
+            if let subtitle = self.subtitleManager?.subtitleForTime(time) {
+                self.subtitlesLabel.text = subtitle
             }
         }
+        observedPlayer = session.player
     }
 
     func playbackController(_ controller: BCOVPlaybackController!,

--- a/Cast/BasicCastPlayer/BasicCastPlayer/AppDelegate.swift
+++ b/Cast/BasicCastPlayer/BasicCastPlayer/AppDelegate.swift
@@ -57,7 +57,6 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         castContainerViewController = GCKCastContext.sharedInstance().createCastContainerController(for: navigationController)
         castContainerViewController?.miniMediaControlsItemEnabled = true
 
-        window = UIWindow(frame: UIScreen.main.bounds)
         window?.rootViewController = castContainerViewController
         window?.makeKeyAndVisible()
 

--- a/Cast/BasicCastPlayer/BasicCastPlayer/AppDelegate.swift
+++ b/Cast/BasicCastPlayer/BasicCastPlayer/AppDelegate.swift
@@ -10,7 +10,7 @@ import UIKit
 import GoogleCast
 
 
-@UIApplicationMain
+@main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/Cast/BasicCastPlayer/BasicCastPlayer/GoogleCastManager.swift
+++ b/Cast/BasicCastPlayer/BasicCastPlayer/GoogleCastManager.swift
@@ -27,15 +27,15 @@ final class GoogleCastManager: NSObject {
 
     var delegate: GoogleCastManagerDelegate?
 
-    fileprivate var sessionManager: GCKSessionManager
-    fileprivate var castMediaController: GCKUIMediaController
+    fileprivate let sessionManager: GCKSessionManager
+    fileprivate let castMediaController: GCKUIMediaController
     fileprivate var currentProgress: TimeInterval?
     fileprivate var currentVideo: BCOVVideo?
     fileprivate var castStreamPosition: TimeInterval?
     fileprivate let posterImageSize = CGSize(width: 480,
                                              height: 720)
-    fileprivate var didContinueCurrentVideo: Bool = false
-    fileprivate var suitableSourceNotFound: Bool = false
+    fileprivate var didContinueCurrentVideo = false
+    fileprivate var suitableSourceNotFound = false
     fileprivate var castMediaInfo: GCKMediaInformation?
 
     override init() {
@@ -56,7 +56,7 @@ final class GoogleCastManager: NSObject {
                 }
 
                 return url.absoluteString.hasPrefix("http://")
-            }else{
+            } else {
                 return false
             }
         }
@@ -66,7 +66,7 @@ final class GoogleCastManager: NSObject {
         var mp4Source: BCOVSource?
 
         for source in filteredSources {
-            let urlString = source.url!.absoluteString
+            guard let urlString = source.url?.absoluteString else { continue }
             let deliveryMethod = source.deliveryMethod
 
             if urlString.contains("hls/v3") &&
@@ -219,7 +219,7 @@ final class GoogleCastManager: NSObject {
 
         if let castSession = GCKCastContext.sharedInstance().sessionManager.currentSession,
            let remoteMediaClient = castSession.remoteMediaClient,
-           let castMediaInfo = castMediaInfo {
+           let castMediaInfo {
             remoteMediaClient.loadMedia(castMediaInfo, with: options)
         }
     }

--- a/Cast/BasicCastPlayer/BasicCastPlayer/GoogleCastManager.swift
+++ b/Cast/BasicCastPlayer/BasicCastPlayer/GoogleCastManager.swift
@@ -10,7 +10,7 @@ import GoogleCast
 import BrightcovePlayerSDK
 
 
-protocol GoogleCastManagerDelegate {
+protocol GoogleCastManagerDelegate: AnyObject {
 
     var playbackController: BCOVPlaybackController? { get }
 
@@ -25,7 +25,7 @@ protocol GoogleCastManagerDelegate {
 
 final class GoogleCastManager: NSObject {
 
-    var delegate: GoogleCastManagerDelegate?
+    weak var delegate: GoogleCastManagerDelegate?
 
     fileprivate let sessionManager: GCKSessionManager
     fileprivate let castMediaController: GCKUIMediaController
@@ -134,8 +134,8 @@ final class GoogleCastManager: NSObject {
         currentVideo = video
 
         let videoURL = url.absoluteString
-        let name = video.properties[BCOVVideo.PropertyKeyName] as! String
-        let durationNumber = video.properties[BCOVVideo.PropertyKeyDuration] as! NSNumber
+        let name = video.properties[BCOVVideo.PropertyKeyName] as? String ?? ""
+        let durationNumber = video.properties[BCOVVideo.PropertyKeyDuration] as? NSNumber
 
         let metaData = GCKMediaMetadata(metadataType: .generic)
         metaData.setString(name, forKey: kGCKMetadataKeyTitle)
@@ -150,7 +150,7 @@ final class GoogleCastManager: NSObject {
 
         var mediaTracks = [GCKMediaTrack]()
 
-        let textTracks = video.properties[BCOVVideo.PropertyKeyTextTracks] as! [[String: AnyHashable]]
+        let textTracks = video.properties[BCOVVideo.PropertyKeyTextTracks] as? [[String: AnyHashable]] ?? []
 
         var trackIdentifier = 0
 
@@ -191,7 +191,7 @@ final class GoogleCastManager: NSObject {
         builder.streamType = .unknown
         builder.contentType = source.deliveryMethod
         builder.metadata = metaData
-        builder.streamDuration = durationNumber.doubleValue
+        builder.streamDuration = durationNumber?.doubleValue ?? 0
         builder.mediaTracks = mediaTracks
 
         castMediaInfo = builder.build()

--- a/Cast/BasicCastPlayer/BasicCastPlayer/ViewController.swift
+++ b/Cast/BasicCastPlayer/BasicCastPlayer/ViewController.swift
@@ -127,18 +127,17 @@ final class ViewController: UIViewController {
     // If you need to extend the behavior of BCOVGoogleCastManager
     // you can customize the GoogleCastManager class in this project
     // and use it instead of BCOVGoogleCastManager.
-    // fileprivate lazy var googleCastManager: GoogleCastManager = GoogleCastManager()
 
-    fileprivate lazy var videos: [BCOVVideo] = .init()
+    fileprivate var videos: [BCOVVideo] = []
 
-    fileprivate lazy var statusBarHidden = false {
+    fileprivate var statusBarHidden = false {
         didSet {
             setNeedsStatusBarAppearanceUpdate()
         }
     }
 
     override var prefersStatusBarHidden: Bool {
-        return statusBarHidden
+        statusBarHidden
     }
 
     override func viewDidLoad() {
@@ -203,11 +202,6 @@ final class ViewController: UIViewController {
 extension ViewController: BCOVPlaybackControllerDelegate {
 
     func playbackController(_ controller: BCOVPlaybackController!,
-                            didAdvanceTo session: BCOVPlaybackSession!) {
-        print("ViewController - Advanced to new session.")
-    }
-
-    func playbackController(_ controller: BCOVPlaybackController!,
                             playbackSession session: BCOVPlaybackSession!,
                             didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {
 
@@ -216,7 +210,7 @@ extension ViewController: BCOVPlaybackControllerDelegate {
         }
 
         if kBCOVPlaybackSessionLifecycleEventFail == lifecycleEvent.eventType,
-           let error = lifecycleEvent.properties["error"] as? NSError {
+           let error = lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError] as? NSError {
             // Report any errors that may have occurred with playback.
             print("ViewController - Playback error: \(error.localizedDescription)")
         }
@@ -270,45 +264,6 @@ extension ViewController: BCOVGoogleCastManagerDelegate {
         print("Suitable source for video not found!")
     }
 }
-
-
-// MARK: - GoogleCastManagerDelegate
-
-// Uncomment this extension if you are using GoogleCastManager
-// instead of BCOVGoogleCastManager
-
-//extension ViewController: GoogleCastManagerDelegate {
-//
-//    func switchedToLocalPlayback(withLastKnownStreamPosition streamPosition: TimeInterval,
-//                                 withError error: Error?) {
-//        if streamPosition > 0,
-//           let playbackController {
-//            playbackController.play()
-//        }
-//
-//        videoContainerView.isHidden = false
-//
-//        if let error {
-//            print("Switched to local playback with error: \(error.localizedDescription)")
-//        }
-//    }
-//
-//    func switchedToRemotePlayback() {
-//        videoContainerView.isHidden = true
-//    }
-//
-//    func castedVideoDidComplete() {
-//        videoContainerView.isHidden = true
-//    }
-//
-//    func castedVideoFailedToPlay() {
-//        print("Failed to play Cast video")
-//    }
-//
-//    func suitableSourceNotFound() {
-//        print("Suitable source for video not found!")
-//    }
-//}
 
 
 // MARK: - UITableViewDataSource

--- a/Cast/BasicCastPlayer/README.md
+++ b/Cast/BasicCastPlayer/README.md
@@ -1,6 +1,6 @@
 # Casting — default receiver (BasicCastPlayer)
 
-Casts to the **default Google media receiver** using Brightcove's `BCOVGoogleCastManager`, added to the playback controller with `playbackController.add(googleCastManager)`. The sample also ships a fully custom `GoogleCastManager` (a `BCOVPlaybackSessionConsumer`) — commented out — that you can swap in when you need behavior the plugin does not cover, such as custom source selection or media-info construction.
+Casts to the **default Google media receiver** using Brightcove's `BCOVGoogleCastManager`, added to the playback controller with `playbackController.add(googleCastManager)`. The sample also ships a fully custom `GoogleCastManager` (a `BCOVPlaybackSessionConsumer`) that you can swap in when you need behavior the plugin does not cover, such as custom source selection or media-info construction.
 
 The default receiver does **not** support DRM or ads and only handles `HLSv3`, `DASH`, and `MP4`. For DRM, SSAI, and HLSv3-or-superior, use [`BrightcoveCastReceiver`](../BrightcoveCastReceiver/).
 

--- a/Cast/BasicCastPlayer/README.md
+++ b/Cast/BasicCastPlayer/README.md
@@ -1,6 +1,6 @@
 # Casting — default receiver (BasicCastPlayer)
 
-Casts to the **default Google media receiver** using Brightcove's `BCOVGoogleCastManager`, added to the playback controller with `playbackController.add(googleCastManager)`. The sample also ships a fully custom `GoogleCastManager` (a `BCOVPlaybackSessionConsumer`) that you can swap in when you need behavior the plugin does not cover, such as custom source selection or media-info construction.
+Casts to the **default Google media receiver** using Brightcove's `BCOVGoogleCastManager`, added to the playback controller with `playbackController.add(googleCastManager)`. The sample also includes a fully custom `GoogleCastManager` (a `BCOVPlaybackSessionConsumer`) as a reference for when you need behavior the plugin does not cover, such as custom source selection or media-info construction.
 
 The default receiver does **not** support DRM or ads and only handles `HLSv3`, `DASH`, and `MP4`. For DRM, SSAI, and HLSv3-or-superior, use [`BrightcoveCastReceiver`](../BrightcoveCastReceiver/).
 

--- a/Cast/BrightcoveCastReceiver/BrightcoveCastReceiver/AppDelegate.swift
+++ b/Cast/BrightcoveCastReceiver/BrightcoveCastReceiver/AppDelegate.swift
@@ -11,7 +11,7 @@ import GoogleCast
 import BrightcoveGoogleCast
 
 
-@UIApplicationMain
+@main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/Cast/BrightcoveCastReceiver/BrightcoveCastReceiver/AppDelegate.swift
+++ b/Cast/BrightcoveCastReceiver/BrightcoveCastReceiver/AppDelegate.swift
@@ -58,7 +58,6 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         castContainerViewController = GCKCastContext.sharedInstance().createCastContainerController(for: navigationController)
         castContainerViewController?.miniMediaControlsItemEnabled = true
 
-        window = UIWindow(frame: UIScreen.main.bounds)
         window?.rootViewController = castContainerViewController
         window?.makeKeyAndVisible()
 

--- a/Cast/BrightcoveCastReceiver/BrightcoveCastReceiver/ViewController.swift
+++ b/Cast/BrightcoveCastReceiver/BrightcoveCastReceiver/ViewController.swift
@@ -33,8 +33,8 @@ final class ViewController: UIViewController {
     @IBOutlet fileprivate weak var headerTableView: UIView! {
         didSet {
             headerTableView.backgroundColor = .systemGroupedBackground
-            headerTableView.layer.borderColor = UIColor.init(white: 0.9,
-                                                             alpha: 1.0).cgColor
+            headerTableView.layer.borderColor = UIColor(white: 0.9,
+                                                        alpha: 1.0).cgColor
             headerTableView.layer.borderWidth = 0.3
             headerTableView.addSubview(headerLabel)
         }
@@ -122,7 +122,7 @@ final class ViewController: UIViewController {
         return playbackController
     }()
 
-    fileprivate var googleCastManager: BCOVGoogleCastManager  = {
+    fileprivate let googleCastManager: BCOVGoogleCastManager = {
         let receiverAppConfig = BCOVReceiverAppConfig()
         receiverAppConfig.accountId = kAccountId
         receiverAppConfig.policyKey = kPolicyKey
@@ -141,9 +141,9 @@ final class ViewController: UIViewController {
         return BCOVGoogleCastManager(forBrightcoveReceiverApp: receiverAppConfig)
     }()
 
-    fileprivate lazy var videos: [BCOVVideo] = .init()
+    fileprivate var videos: [BCOVVideo] = []
 
-    fileprivate lazy var statusBarHidden = false {
+    fileprivate var statusBarHidden = false {
         didSet {
             setNeedsStatusBarAppearanceUpdate()
         }
@@ -188,9 +188,11 @@ final class ViewController: UIViewController {
 
         playbackService.findPlaylist(withConfiguration: configuration,
                                      queryParameters: queryParams) {
-            [self] (playlist: BCOVPlaylist?,
-                    json: Any?,
-                    error: Error?) in
+            [weak self] (playlist: BCOVPlaylist?,
+                         json: Any?,
+                         error: Error?) in
+
+            guard let self else { return }
 
             if let playlist {
                 let videos = playlist.videos
@@ -215,11 +217,6 @@ final class ViewController: UIViewController {
 extension ViewController: BCOVPlaybackControllerDelegate {
 
     func playbackController(_ controller: BCOVPlaybackController!,
-                            didAdvanceTo session: BCOVPlaybackSession!) {
-        print("ViewController - Advanced to new session.")
-    }
-
-    func playbackController(_ controller: BCOVPlaybackController!,
                             playbackSession session: BCOVPlaybackSession!,
                             didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {
 
@@ -228,7 +225,7 @@ extension ViewController: BCOVPlaybackControllerDelegate {
         }
 
         if kBCOVPlaybackSessionLifecycleEventFail == lifecycleEvent.eventType,
-           let error = lifecycleEvent.properties["error"] as? NSError {
+           let error = lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError] as? NSError {
             // Report any errors that may have occurred with playback.
             print("ViewController - Playback error: \(error.localizedDescription)")
         }
@@ -312,7 +309,7 @@ extension ViewController: UITableViewDataSource {
     }
 
     func numberOfSections(in tableView: UITableView) -> Int {
-        return videos.count > 0 ? 2 : 0
+        return !videos.isEmpty ? 2 : 0
     }
 
     func tableView(_ tableView: UITableView,

--- a/Cast/BrightcoveCastReceiver/BrightcoveCastReceiver/ViewController.swift
+++ b/Cast/BrightcoveCastReceiver/BrightcoveCastReceiver/ViewController.swift
@@ -126,7 +126,9 @@ final class ViewController: UIViewController {
         let receiverAppConfig = BCOVReceiverAppConfig()
         receiverAppConfig.accountId = kAccountId
         receiverAppConfig.policyKey = kPolicyKey
-        receiverAppConfig.splashScreen = "https://picsum.photos/seed/brightcove/1280/720"
+
+        // You can specify a custom splash screen image
+        // receiverAppConfig.splashScreen = "https://your-domain.example/splash.jpg"
 
         // You can specify a customized player
         // receiverAppConfig.playerUrl = "https://players.brightcove.net/5434391461001/nVM2434Z1_default/index.min.js"

--- a/Cast/BrightcoveCastReceiver/BrightcoveCastReceiver/ViewController.swift
+++ b/Cast/BrightcoveCastReceiver/BrightcoveCastReceiver/ViewController.swift
@@ -126,7 +126,7 @@ final class ViewController: UIViewController {
         let receiverAppConfig = BCOVReceiverAppConfig()
         receiverAppConfig.accountId = kAccountId
         receiverAppConfig.policyKey = kPolicyKey
-        receiverAppConfig.splashScreen = "https://solutions.brightcove.com/jblaker/cast-splash.jpg"
+        receiverAppConfig.splashScreen = "https://picsum.photos/seed/brightcove/1280/720"
 
         // You can specify a customized player
         // receiverAppConfig.playerUrl = "https://players.brightcove.net/5434391461001/nVM2434Z1_default/index.min.js"

--- a/DAI/BasicDAIPlayer-iOS/BasicDAIPlayer/AppDelegate.swift
+++ b/DAI/BasicDAIPlayer-iOS/BasicDAIPlayer/AppDelegate.swift
@@ -9,7 +9,7 @@ import AVFoundation
 import UIKit
 
 
-@UIApplicationMain
+@main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/DAI/BasicDAIPlayer-iOS/BasicDAIPlayer/AssetKeyViewController.swift
+++ b/DAI/BasicDAIPlayer-iOS/BasicDAIPlayer/AssetKeyViewController.swift
@@ -14,7 +14,7 @@ final class AssetKeyViewController: BaseViewController {
 
     override func setupPlaybackController() {
         let sdkManager = BCOVPlayerSDKManager.sharedManager()
-        guard let fps else { return }
+        guard let fps, let playerView else { return }
 
         let imaSettings = IMASettings()
         imaSettings.language = NSLocale.current.languageCode ?? "en"
@@ -38,15 +38,11 @@ final class AssetKeyViewController: BaseViewController {
         let daiSessionProvider = sdkManager.createDAISessionProvider(with: imaSettings,
                                                                      adsRenderingSettings: adsRenderingSettings,
                                                                      adsRequestPolicy: adsRequestPolicy,
-                                                                     adContainer: playerView!.contentOverlayView,
+                                                                     adContainer: playerView.contentOverlayView,
                                                                      viewController: self,
                                                                      companionSlots: nil,
                                                                      upstreamSessionProvider: fps,
                                                                      options: daiPlaybackSessionOptions)
-
-        guard let playerView else {
-            return
-        }
 
         let playbackController = sdkManager.createPlaybackController(withSessionProvider: daiSessionProvider,
                                                                      viewStrategy: nil)

--- a/DAI/BasicDAIPlayer-iOS/BasicDAIPlayer/AssetKeyViewController.swift
+++ b/DAI/BasicDAIPlayer-iOS/BasicDAIPlayer/AssetKeyViewController.swift
@@ -17,7 +17,7 @@ final class AssetKeyViewController: BaseViewController {
         guard let fps else { return }
 
         let imaSettings = IMASettings()
-        imaSettings.language = NSLocale.current.languageCode!
+        imaSettings.language = NSLocale.current.languageCode ?? "en"
 
         let adsRenderingSettings = IMAAdsRenderingSettings()
         adsRenderingSettings.linkOpenerDelegate = self

--- a/DAI/BasicDAIPlayer-iOS/BasicDAIPlayer/BaseViewController.swift
+++ b/DAI/BasicDAIPlayer-iOS/BasicDAIPlayer/BaseViewController.swift
@@ -67,10 +67,9 @@ class BaseViewController: UIViewController {
     var playbackController: BCOVPlaybackController?
 
     fileprivate var notificationReceipt: AnyObject?
-    fileprivate lazy var adIsPlaying = false
-    fileprivate lazy var isBrowserOpen = false
+    fileprivate var adIsPlaying = false
 
-    fileprivate lazy var statusBarHidden = false {
+    fileprivate var statusBarHidden = false {
         didSet {
             if let navigationController {
                 navigationController.isNavigationBarHidden = statusBarHidden
@@ -83,7 +82,7 @@ class BaseViewController: UIViewController {
     }
 
     override var prefersStatusBarHidden: Bool {
-        return statusBarHidden
+        statusBarHidden
     }
 
     override func viewDidLoad() {
@@ -94,20 +93,7 @@ class BaseViewController: UIViewController {
         resumeAdAfterForeground()
 
         if #available(iOS 14.5, *) {
-            ATTrackingManager.requestTrackingAuthorization { status in
-                switch (status) {
-                    case .authorized:
-                        print("Authorized Tracking Permission")
-                    case .denied:
-                        print("Denied Tracking Permission")
-                    case .notDetermined:
-                        print("Not Determined Tracking Permission")
-                    case .restricted:
-                        print("Restricted Tracking Permission")
-                    @unknown default:
-                        print("Default value Trackin Permission")
-                }
-
+            ATTrackingManager.requestTrackingAuthorization { _ in
                 print("IDFA: \(ASIdentifierManager.shared().advertisingIdentifier.uuidString)")
 
                 DispatchQueue.main.async { [self] in
@@ -129,14 +115,13 @@ class BaseViewController: UIViewController {
         // the foreground.
         notificationReceipt = NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification,
                                                                      object: nil,
-                                                                     queue: nil) {
-            [weak self] (notificatin: Notification) in
+                                                                     queue: nil) { [weak self] _ in
             guard let self,
                   let playbackController else {
                 return
             }
 
-            if adIsPlaying && !isBrowserOpen {
+            if adIsPlaying {
                 playbackController.resumeAd()
             }
         }
@@ -152,7 +137,7 @@ class BaseViewController: UIViewController {
             guard let video,
                   let playbackController else {
                 if let error {
-                    print("ViewController - Error retrieving video: \(error.localizedDescription)")
+                    print("BaseViewController - Error retrieving video: \(error.localizedDescription)")
                 }
 
                 return
@@ -202,41 +187,30 @@ class BaseViewController: UIViewController {
 extension BaseViewController: BCOVPlaybackControllerDelegate {
 
     func playbackController(_ controller: BCOVPlaybackController!,
-                            didAdvanceTo session: BCOVPlaybackSession!) {
-        print("ViewController - Advanced to new session.")
-    }
-
-    func playbackController(_ controller: BCOVPlaybackController!,
                             playbackSession session: BCOVPlaybackSession,
                             didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {
 
         if kBCOVPlaybackSessionLifecycleEventFail == lifecycleEvent.eventType,
-           let error = lifecycleEvent.properties["error"] as? NSError {
+           let error = lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError] as? NSError {
             // Report any errors that may have occurred with playback.
-            print("ViewController - Playback error: \(error.localizedDescription)")
+            print("BaseViewController - Playback error: \(error.localizedDescription)")
         }
 
-        // Ad events are emitted by the BCOVIMA plugin through lifecycle events.
-        // The events are defined BCOVIMAComponent.h.
+        // Ad events are emitted by the BCOVDAI plugin through lifecycle events.
+        // The events are defined in BCOVDAIComponent.h.
         if kBCOVDAILifecycleEventAdsLoaderLoaded == lifecycleEvent.eventType,
            let adsManager = lifecycleEvent.properties[kBCOVDAILifecycleEventPropertyKeyAdsManager] as? IMAAdsManager {
-            print("ViewController - Ads loaded.")
-
             // Lower the volume of ads by half.
             adsManager.volume = adsManager.volume / 2.0
-            print("ViewController - IMAAdsManager.volume set to \(String(format: "%0.1f", adsManager.volume))")
+            print("BaseViewController - IMAAdsManager.volume set to \(String(format: "%0.1f", adsManager.volume))")
 
         } else if kBCOVDAILifecycleEventAdsManagerDidReceiveAdEvent == lifecycleEvent.eventType,
-                  let adEvent = lifecycleEvent.properties["adEvent"] as? IMAAdEvent {
+                  let adEvent = lifecycleEvent.properties[kBCOVDAILifecycleEventPropertyKeyAdEvent] as? IMAAdEvent {
             switch adEvent.type {
                 case .STARTED:
-                    print("ViewController - Ad Started.")
                     adIsPlaying = true
                 case .COMPLETE:
-                    print("ViewController - Ad Completed.")
                     adIsPlaying = false
-                case .ALL_ADS_COMPLETED:
-                    print("ViewController - All ads completed.")
                 default:
                     break
             }
@@ -295,8 +269,6 @@ extension BaseViewController: BCOVDAIPlaybackSessionDelegate {
         // https://support.google.com/admanager/answer/7320899?hl=en
 
         adsRequest.adTagParameters = [ "tfcd1": "1" ]
-
-        print("ViewController - IMAStreamRequest.adTagParameters \(String(describing: adsRequest.adTagParameters))")
     }
 }
 
@@ -305,13 +277,7 @@ extension BaseViewController: BCOVDAIPlaybackSessionDelegate {
 
 extension BaseViewController: IMALinkOpenerDelegate {
 
-    func linkOpenerDidOpen(inAppLink linkOpener: NSObject) {
-        print("ViewController - linkOpenerDidOpen")
-    }
-
     func linkOpenerDidClose(inAppLink linkOpener: NSObject) {
-        print("ViewController - linkOpenerDidClose")
-
         // Called when the in-app browser has closed.
         guard let playbackController else { return }
         playbackController.resumeAd()

--- a/DAI/BasicDAIPlayer-iOS/BasicDAIPlayer/BaseViewController.swift
+++ b/DAI/BasicDAIPlayer-iOS/BasicDAIPlayer/BaseViewController.swift
@@ -268,7 +268,7 @@ extension BaseViewController: BCOVDAIPlaybackSessionDelegate {
         // for demo purposes, modify the adTagParameters
         // https://support.google.com/admanager/answer/7320899?hl=en
 
-        adsRequest.adTagParameters = [ "tfcd1": "1" ]
+        adsRequest.adTagParameters = [ "tfcd": "0" ]
     }
 }
 

--- a/DAI/BasicDAIPlayer-iOS/BasicDAIPlayer/VideoPropertiesViewController.swift
+++ b/DAI/BasicDAIPlayer-iOS/BasicDAIPlayer/VideoPropertiesViewController.swift
@@ -14,7 +14,7 @@ final class VideoPropertiesViewController: BaseViewController {
 
     override func setupPlaybackController() {
         let sdkManager = BCOVPlayerSDKManager.sharedManager()
-        guard let fps else { return }
+        guard let fps, let playerView else { return }
 
         let imaSettings = IMASettings()
         imaSettings.language = NSLocale.current.languageCode ?? "en"
@@ -37,15 +37,11 @@ final class VideoPropertiesViewController: BaseViewController {
         let daiSessionProvider = sdkManager.createDAISessionProvider(with: imaSettings,
                                                                      adsRenderingSettings: adsRenderingSettings,
                                                                      adsRequestPolicy: adsRequestPolicy,
-                                                                     adContainer: playerView!.contentOverlayView,
+                                                                     adContainer: playerView.contentOverlayView,
                                                                      viewController: self,
                                                                      companionSlots: nil,
                                                                      upstreamSessionProvider: fps,
                                                                      options: daiPlaybackSessionOptions)
-
-        guard let playerView else {
-            return
-        }
 
         let playbackController = sdkManager.createPlaybackController(withSessionProvider: daiSessionProvider,
                                                                      viewStrategy: nil)

--- a/DAI/BasicDAIPlayer-iOS/BasicDAIPlayer/VideoPropertiesViewController.swift
+++ b/DAI/BasicDAIPlayer-iOS/BasicDAIPlayer/VideoPropertiesViewController.swift
@@ -1,5 +1,5 @@
 //
-//  ViewController.swift
+//  VideoPropertiesViewController.swift
 //  BasicDAIPlayer
 //
 //  Copyright © 2026 Brightcove, Inc. All rights reserved.
@@ -17,13 +17,13 @@ final class VideoPropertiesViewController: BaseViewController {
         guard let fps else { return }
 
         let imaSettings = IMASettings()
-        imaSettings.language = NSLocale.current.languageCode!
+        imaSettings.language = NSLocale.current.languageCode ?? "en"
 
         let adsRenderingSettings = IMAAdsRenderingSettings()
         adsRenderingSettings.linkOpenerDelegate = self
         adsRenderingSettings.linkOpenerPresentingController = self
 
-        let adsRequestPolicy = BCOVDAIAdsRequestPolicy.videoProperties();
+        let adsRequestPolicy = BCOVDAIAdsRequestPolicy.videoProperties()
 
         // BCOVDAIPlaybackSessionDelegate defines -willCallIMAAdsLoaderRequestAdsWithRequest:
         // which allows us to modify the IMAStreamRequest object before it is used to load ads.

--- a/DAI/BasicDAIPlayer-tvOS/BasicDAIPlayer/AppDelegate.swift
+++ b/DAI/BasicDAIPlayer-tvOS/BasicDAIPlayer/AppDelegate.swift
@@ -9,7 +9,7 @@ import AVFoundation
 import UIKit
 
 
-@UIApplicationMain
+@main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/DAI/BasicDAIPlayer-tvOS/BasicDAIPlayer/ViewController.swift
+++ b/DAI/BasicDAIPlayer-tvOS/BasicDAIPlayer/ViewController.swift
@@ -5,7 +5,6 @@
 //  Copyright © 2026 Brightcove, Inc. All rights reserved.
 //
 
-import AdSupport
 import AppTrackingTransparency
 import UIKit
 import GoogleInteractiveMediaAds
@@ -21,15 +20,21 @@ let kVideoId = "1753980443013591663"
 let kGoogleDAISourceId = "2528370"
 let kGoogleDAIVideoId = "tears-of-steel"
 
+/// Demonstrates Dynamic Ad Insertion (DAI) playback on tvOS.
+///
+/// Chains a Google DAI session provider on top of a FairPlay session provider,
+/// requests a Video Cloud video, tags it with the Google DAI source and video
+/// IDs, and plays the ad-stitched stream in a `BCOVTVPlayerView` using the
+/// Video Properties stream-request policy.
 final class ViewController: UIViewController {
 
-    fileprivate lazy var playbackService: BCOVPlaybackService = {
+    private lazy var playbackService: BCOVPlaybackService = {
         let factory = BCOVPlaybackServiceRequestFactory(withAccountId: kAccountId,
                                                         policyKey: kPolicyKey)
         return .init(withRequestFactory: factory)
     }()
 
-    fileprivate lazy var playerView: BCOVTVPlayerView? = {
+    private lazy var playerView: BCOVTVPlayerView? = {
         let options = BCOVTVPlayerViewOptions()
         options.presentingViewController = self
         options.automaticControlTypeSelection = true
@@ -45,7 +50,7 @@ final class ViewController: UIViewController {
         return playerView
     }()
 
-    fileprivate lazy var playbackController: BCOVPlaybackController? = {
+    private lazy var playbackController: BCOVPlaybackController? = {
 
         let sdkManager = BCOVPlayerSDKManager.sharedManager()
         let authProxy = BCOVFPSBrightcoveAuthProxy(withPublisherId: nil,
@@ -55,11 +60,11 @@ final class ViewController: UIViewController {
                                                            upstreamSessionProvider: nil)
 
         let imaSettings = IMASettings()
-        imaSettings.language = NSLocale.current.languageCode!
+        imaSettings.language = NSLocale.current.languageCode ?? "en"
 
         let adsRenderingSettings = IMAAdsRenderingSettings()
 
-        let adsRequestPolicy = BCOVDAIAdsRequestPolicy.videoProperties();
+        let adsRequestPolicy = BCOVDAIAdsRequestPolicy.videoProperties()
 
         // Opt in to automatic DAI session recovery (on by default; see
         // `kBCOVDAIOptionAutomaticRecoveryEnabledKey` in BCOVDAIComponent.h).
@@ -102,34 +107,18 @@ final class ViewController: UIViewController {
     }
 
     override var preferredFocusEnvironments: [UIFocusEnvironment] {
-        return [playerView?.controlsView ?? self]
+        [playerView?.controlsView ?? self]
     }
 
     @objc
-    fileprivate func requestTrackingAuthorization() {
+    private func requestTrackingAuthorization() {
         if #available(tvOS 14.5, *) {
-            ATTrackingManager.requestTrackingAuthorization { status in
-                switch (status) {
-                    case .authorized:
-                        print("Authorized Tracking Permission")
-                    case .denied:
-                        print("Denied Tracking Permission")
-                    case .notDetermined:
-                        print("Not Determined Tracking Permission")
-                    case .restricted:
-                        print("Restricted Tracking Permission")
-                    @unknown default:
-                        print("Default value Trackin Permission")
-                }
-
-                print("IDFA: \(ASIdentifierManager.shared().advertisingIdentifier.uuidString)")
-
+            ATTrackingManager.requestTrackingAuthorization { _ in
                 DispatchQueue.main.async { [self] in
                     // Tracking authorization completed.
                     // Start loading ads here.
                     requestContentFromPlaybackService()
                 }
-
             }
         } else {
             requestContentFromPlaybackService()
@@ -140,7 +129,7 @@ final class ViewController: UIViewController {
                                                   object: nil)
     }
 
-    fileprivate func requestContentFromPlaybackService() {
+    private func requestContentFromPlaybackService() {
         let configuration = [BCOVPlaybackService.ConfigurationKeyAssetID: kVideoId]
 
         playbackService.findVideo(withConfiguration: configuration,
@@ -177,7 +166,7 @@ final class ViewController: UIViewController {
 #endif
 
                 let updatedVideo = video.update { (mutableVideo: BCOVMutableVideo?) in
-                    guard let mutableVideo = mutableVideo else {
+                    guard let mutableVideo else {
                         return
                     }
 
@@ -204,22 +193,17 @@ final class ViewController: UIViewController {
 extension ViewController: BCOVPlaybackControllerDelegate {
 
     func playbackController(_ controller: BCOVPlaybackController!,
-                            didAdvanceTo session: BCOVPlaybackSession!) {
-        print("ViewController - Advanced to new session.")
-    }
-
-    func playbackController(_ controller: BCOVPlaybackController!,
                             playbackSession session: BCOVPlaybackSession,
                             didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {
 
         if kBCOVPlaybackSessionLifecycleEventFail == lifecycleEvent.eventType,
-           let error = lifecycleEvent.properties["error"] as? NSError {
+           let error = lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError] as? NSError {
             // Report any errors that may have occurred with playback.
             print("ViewController - Playback error: \(error.localizedDescription)")
         }
 
-        // Ad events are emitted by the BCOVIMA plugin through lifecycle events.
-        // The events are defined BCOVIMAComponent.h.
+        // Ad events are emitted by the BCOVDAI plugin through lifecycle events.
+        // The events are defined in BCOVDAIComponent.h.
         if kBCOVDAILifecycleEventAdsLoaderLoaded == lifecycleEvent.eventType,
            let adsManager = lifecycleEvent.properties[kBCOVDAILifecycleEventPropertyKeyAdsManager] as? IMAAdsManager {
             print("ViewController - Ads loaded.")

--- a/DAI/BasicDAIPlayer-tvOS/BasicDAIPlayer/ViewController.swift
+++ b/DAI/BasicDAIPlayer-tvOS/BasicDAIPlayer/ViewController.swift
@@ -72,18 +72,18 @@ final class ViewController: UIViewController {
             kBCOVDAIOptionAutomaticRecoveryEnabledKey: true
         ]
 
+        guard let playerView else {
+            return nil
+        }
+
         let daiSessionProvider = sdkManager.createDAISessionProvider(with: imaSettings,
                                                                      adsRenderingSettings: adsRenderingSettings,
                                                                      adsRequestPolicy: adsRequestPolicy,
-                                                                     adContainer: playerView!.contentOverlayView,
+                                                                     adContainer: playerView.contentOverlayView,
                                                                      viewController: self,
                                                                      companionSlots: nil,
                                                                      upstreamSessionProvider: fps,
                                                                      options: daiOptions)
-
-        guard let playerView else {
-            return nil
-        }
 
         let playbackController = sdkManager.createPlaybackController(withSessionProvider: daiSessionProvider,
                                                                      viewStrategy: nil)

--- a/DRM/BasicFairPlayPlayer/AppDelegate.swift
+++ b/DRM/BasicFairPlayPlayer/AppDelegate.swift
@@ -9,7 +9,7 @@ import AVFoundation
 import UIKit
 
 
-@UIApplicationMain
+@main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/DRM/BasicFairPlayPlayer/ViewController.swift
+++ b/DRM/BasicFairPlayPlayer/ViewController.swift
@@ -5,6 +5,20 @@
 //  Copyright © 2026 Brightcove, Inc. All rights reserved.
 //
 
+/*
+ * This sample app shows how to play FairPlay-protected content from Video Cloud.
+ *
+ * The FairPlay session provider is created with
+ * `BCOVPlayerSDKManager.createFairPlaySessionProvider(withApplicationCertificate:authorizationProxy:upstreamSessionProvider:)`
+ * and used as the session provider for the playback controller. Passing `nil`
+ * for the application certificate and for the auth proxy's publisher and
+ * application IDs configures the provider to use Brightcove's FairPlay license
+ * service, the common Video Cloud setup.
+ *
+ * FairPlay content can only be decrypted on physical iOS and tvOS devices, so
+ * the sample detects the simulator and displays a warning instead of playing.
+ */
+
 import UIKit
 import BrightcovePlayerSDK
 
@@ -70,14 +84,14 @@ final class ViewController: UIViewController {
         return playbackController
     }()
 
-    fileprivate lazy var statusBarHidden = false {
+    fileprivate var statusBarHidden = false {
         didSet {
             setNeedsStatusBarAppearanceUpdate()
         }
     }
 
     override var prefersStatusBarHidden: Bool {
-        return statusBarHidden
+        statusBarHidden
     }
 
     override func viewDidLoad() {
@@ -137,16 +151,11 @@ final class ViewController: UIViewController {
 extension ViewController: BCOVPlaybackControllerDelegate {
 
     func playbackController(_ controller: BCOVPlaybackController!,
-                            didAdvanceTo session: BCOVPlaybackSession!) {
-        print("ViewController - Advanced to new session.")
-    }
-
-    func playbackController(_ controller: BCOVPlaybackController!,
                             playbackSession session: BCOVPlaybackSession,
                             didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {
 
         if kBCOVPlaybackSessionLifecycleEventFail == lifecycleEvent.eventType,
-           let error = lifecycleEvent.properties["error"] as? NSError {
+           let error = lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError] as? NSError {
             // Report any errors that may have occurred with playback.
             print("ViewController - Playback error: \(error.localizedDescription)")
         }

--- a/FreeWheel/BasicFreeWheelPlayer/AppDelegate.swift
+++ b/FreeWheel/BasicFreeWheelPlayer/AppDelegate.swift
@@ -9,7 +9,7 @@ import AVFoundation
 import UIKit
 
 
-@UIApplicationMain
+@main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/FreeWheel/BasicFreeWheelPlayer/ViewController.swift
+++ b/FreeWheel/BasicFreeWheelPlayer/ViewController.swift
@@ -5,6 +5,22 @@
 //  Copyright © 2026 Brightcove, Inc. All rights reserved.
 //
 
+/*
+ * This sample app shows how to play Video Cloud content with FreeWheel ads.
+ *
+ * A FreeWheel session provider, created with
+ * `BCOVPlayerSDKManager.createFWSessionProvider(adContextPolicy:upstreamSessionProvider:options:)`,
+ * is layered on top of a FairPlay session provider so FairPlay-protected content
+ * still plays. The ad context policy closure runs before each session is delivered
+ * and builds the FreeWheel ad request: it sets the video display base, the request
+ * configuration (server URL, player profile, and player dimensions), the
+ * site-section and video-asset configurations, and the temporal slots for the
+ * preroll, midroll, and postroll ads.
+ *
+ * App Tracking Transparency authorization is requested on first activation, before
+ * content is loaded, so the ad request can use the advertising identifier.
+ */
+
 import AdSupport
 import AppTrackingTransparency
 import UIKit
@@ -155,14 +171,14 @@ final class ViewController: UIViewController {
         }
     }()
 
-    fileprivate lazy var statusBarHidden = false {
+    fileprivate var statusBarHidden = false {
         didSet {
             setNeedsStatusBarAppearanceUpdate()
         }
     }
 
     override var prefersStatusBarHidden: Bool {
-        return statusBarHidden
+        statusBarHidden
     }
 
     override func viewDidLoad() {
@@ -188,7 +204,7 @@ final class ViewController: UIViewController {
                     case .restricted:
                         print("Restricted Tracking Permission")
                     @unknown default:
-                        print("Default value Trackin Permission")
+                        print("Default value Tracking Permission")
                 }
 
                 print("IDFA: \(ASIdentifierManager.shared().advertisingIdentifier.uuidString)")
@@ -260,16 +276,11 @@ final class ViewController: UIViewController {
 extension ViewController: BCOVPlaybackControllerDelegate {
 
     func playbackController(_ controller: BCOVPlaybackController!,
-                            didAdvanceTo session: BCOVPlaybackSession!) {
-        print("ViewController - Advanced to new session.")
-    }
-
-    func playbackController(_ controller: BCOVPlaybackController!,
                             playbackSession session: BCOVPlaybackSession,
                             didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {
 
         if kBCOVPlaybackSessionLifecycleEventFail == lifecycleEvent.eventType,
-           let error = lifecycleEvent.properties["error"] as? NSError {
+           let error = lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError] as? NSError {
             // Report any errors that may have occurred with playback.
             print("ViewController - Playback error: \(error.localizedDescription)")
         }

--- a/IMA/BasicIMAPlayer-iOS/BasicIMAPlayer/AppDelegate.swift
+++ b/IMA/BasicIMAPlayer-iOS/BasicIMAPlayer/AppDelegate.swift
@@ -9,7 +9,7 @@ import AVFoundation
 import UIKit
 
 
-@UIApplicationMain
+@main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/IMA/BasicIMAPlayer-iOS/BasicIMAPlayer/BCOVVideo+Helpers.swift
+++ b/IMA/BasicIMAPlayer-iOS/BasicIMAPlayer/BCOVVideo+Helpers.swift
@@ -21,8 +21,8 @@ extension BCOVVideo {
             return self
         }
 
-        let durationMiliSeconds = durationNum.doubleValue
-        let midpointSeconds = (durationMiliSeconds / 2) / 1000
+        let durationMilliseconds = durationNum.doubleValue
+        let midpointSeconds = (durationMilliseconds / 2) / 1000
         let midpointTime = CMTimeMakeWithSeconds(midpointSeconds, preferredTimescale: 1)
 
         let cuePointPositionTypeAfter = CMTime.positiveInfinity

--- a/IMA/BasicIMAPlayer-iOS/BasicIMAPlayer/BaseViewController.swift
+++ b/IMA/BasicIMAPlayer-iOS/BasicIMAPlayer/BaseViewController.swift
@@ -69,8 +69,7 @@ class BaseViewController: UIViewController {
     var playbackController: BCOVPlaybackController?
 
     fileprivate var notificationReceipt: AnyObject?
-    fileprivate lazy var adIsPlaying = false
-    fileprivate lazy var isBrowserOpen = false
+    fileprivate var adIsPlaying = false
 
     fileprivate lazy var statusBarHidden = false {
         didSet {
@@ -97,7 +96,7 @@ class BaseViewController: UIViewController {
 
         if #available(iOS 14.5, *) {
             ATTrackingManager.requestTrackingAuthorization { status in
-                switch (status) {
+                switch status {
                     case .authorized:
                         print("Authorized Tracking Permission")
                     case .denied:
@@ -107,7 +106,7 @@ class BaseViewController: UIViewController {
                     case .restricted:
                         print("Restricted Tracking Permission")
                     @unknown default:
-                        print("Default value Trackin Permission")
+                        print("Default value Tracking Permission")
                 }
 
                 print("IDFA: \(ASIdentifierManager.shared().advertisingIdentifier.uuidString)")
@@ -132,13 +131,13 @@ class BaseViewController: UIViewController {
         notificationReceipt = NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification,
                                                                      object: nil,
                                                                      queue: nil) {
-            [weak self] (notificatin: Notification) in
+            [weak self] (notification: Notification) in
             guard let self,
                   let playbackController else {
                 return
             }
 
-            if adIsPlaying && !isBrowserOpen {
+            if adIsPlaying {
                 playbackController.resumeAd()
             }
         }
@@ -148,10 +147,11 @@ class BaseViewController: UIViewController {
         let configuration = [BCOVPlaybackService.ConfigurationKeyAssetID: kVideoId]
         playbackService.findVideo(withConfiguration: configuration,
                                   queryParameters: nil) {
-            [self] (video: BCOVVideo?,
-                    jsonResponse: Any?,
-                    error: Error?) in
-            guard let video,
+            [weak self] (video: BCOVVideo?,
+                         jsonResponse: Any?,
+                         error: Error?) in
+            guard let self,
+                  let video,
                   let playbackController else {
                 if let error {
                     print("ViewController - Error retrieving video: \(error.localizedDescription)")
@@ -177,7 +177,7 @@ class BaseViewController: UIViewController {
                 alert.addAction(.init(title: "OK", style: .default))
 
                 DispatchQueue.main.async { [self] in
-                    present(alert, animated: true)
+                    self.present(alert, animated: true)
                 }
 
                 return
@@ -204,16 +204,11 @@ class BaseViewController: UIViewController {
 extension BaseViewController: BCOVPlaybackControllerDelegate {
 
     func playbackController(_ controller: BCOVPlaybackController!,
-                            didAdvanceTo session: BCOVPlaybackSession!) {
-        print("ViewController - Advanced to new session.")
-    }
-
-    func playbackController(_ controller: BCOVPlaybackController!,
-                            playbackSession session: BCOVPlaybackSession,
+                            playbackSession session: BCOVPlaybackSession!,
                             didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {
 
         if kBCOVPlaybackSessionLifecycleEventFail == lifecycleEvent.eventType,
-           let error = lifecycleEvent.properties["error"] as? NSError {
+           let error = lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError] as? NSError {
             // Report any errors that may have occurred with playback.
             print("ViewController - Playback error: \(error.localizedDescription)")
         }
@@ -222,23 +217,17 @@ extension BaseViewController: BCOVPlaybackControllerDelegate {
         // The events are defined BCOVIMAComponent.h.
         if kBCOVIMALifecycleEventAdsLoaderLoaded == lifecycleEvent.eventType,
            let adsManager = lifecycleEvent.properties[kBCOVIMALifecycleEventPropertyKeyAdsManager] as? IMAAdsManager {
-            print("ViewController - Ads loaded.")
-
             // Lower the volume of ads by half.
             adsManager.volume = adsManager.volume / 2.0
             print("ViewController - IMAAdsManager.volume set to \(String(format: "%0.1f", adsManager.volume))")
 
         } else if kBCOVIMALifecycleEventAdsManagerDidReceiveAdEvent == lifecycleEvent.eventType,
-                  let adEvent = lifecycleEvent.properties["adEvent"] as? IMAAdEvent {
+                  let adEvent = lifecycleEvent.properties[kBCOVIMALifecycleEventPropertyKeyAdEvent] as? IMAAdEvent {
             switch adEvent.type {
                 case .STARTED:
-                    print("ViewController - Ad Started.")
                     adIsPlaying = true
                 case .COMPLETE:
-                    print("ViewController - Ad Completed.")
                     adIsPlaying = false
-                case .ALL_ADS_COMPLETED:
-                    print("ViewController - All ads completed.")
                 default:
                     break
             }
@@ -306,13 +295,7 @@ extension BaseViewController: BCOVIMAPlaybackSessionDelegate {
 
 extension BaseViewController: IMALinkOpenerDelegate {
 
-    func linkOpenerDidOpen(inAppLink linkOpener: NSObject) {
-        print("ViewController - linkOpenerDidOpen")
-    }
-
     func linkOpenerDidClose(inAppLink linkOpener: NSObject) {
-        print("ViewController - linkOpenerDidClose")
-
         // Called when the in-app browser has closed.
         guard let playbackController else { return }
         playbackController.resumeAd()

--- a/IMA/BasicIMAPlayer-iOS/BasicIMAPlayer/VASTOMViewController.swift
+++ b/IMA/BasicIMAPlayer-iOS/BasicIMAPlayer/VASTOMViewController.swift
@@ -14,7 +14,7 @@ final class VASTOMViewController: BaseViewController {
 
     override func setupPlaybackController() {
         let imaSettings = IMASettings()
-        imaSettings.language = NSLocale.current.languageCode!
+        imaSettings.language = NSLocale.current.languageCode ?? "en"
 
         let renderSettings = IMAAdsRenderingSettings()
         renderSettings.linkOpenerPresentingController = self

--- a/IMA/BasicIMAPlayer-iOS/BasicIMAPlayer/VASTViewController.swift
+++ b/IMA/BasicIMAPlayer-iOS/BasicIMAPlayer/VASTViewController.swift
@@ -16,7 +16,7 @@ final class VASTViewController: BaseViewController {
 
     override func setupPlaybackController() {
         let imaSettings = IMASettings()
-        imaSettings.language = NSLocale.current.languageCode!
+        imaSettings.language = NSLocale.current.languageCode ?? "en"
 
         let renderSettings = IMAAdsRenderingSettings()
         renderSettings.linkOpenerPresentingController = self

--- a/IMA/BasicIMAPlayer-iOS/BasicIMAPlayer/VMAPViewController.swift
+++ b/IMA/BasicIMAPlayer-iOS/BasicIMAPlayer/VMAPViewController.swift
@@ -14,7 +14,7 @@ final class VMAPViewController: BaseViewController {
 
     override func setupPlaybackController() {
         let imaSettings = IMASettings()
-        imaSettings.language = NSLocale.current.languageCode!
+        imaSettings.language = NSLocale.current.languageCode ?? "en"
 
         let renderSettings = IMAAdsRenderingSettings()
         renderSettings.linkOpenerPresentingController = self
@@ -31,7 +31,7 @@ final class VMAPViewController: BaseViewController {
 
         var adsRequestPolicy: BCOVIMAAdsRequestPolicy?
 
-        if (useVideoProperties) {
+        if useVideoProperties {
             adsRequestPolicy = .videoPropertiesVMAPAdTagUrl()
         } else {
             adsRequestPolicy = .init(vmapAdTagUrl: kVMAPAdTagURL)

--- a/IMA/NativeControlsIMAPlayer-tvOS/NativeControlsIMAPlayer/AppDelegate.swift
+++ b/IMA/NativeControlsIMAPlayer-tvOS/NativeControlsIMAPlayer/AppDelegate.swift
@@ -9,7 +9,7 @@ import AVFoundation
 import UIKit
 
 
-@UIApplicationMain
+@main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/IMA/NativeControlsIMAPlayer-tvOS/NativeControlsIMAPlayer/ViewController.swift
+++ b/IMA/NativeControlsIMAPlayer-tvOS/NativeControlsIMAPlayer/ViewController.swift
@@ -5,7 +5,17 @@
 //  Copyright © 2026 Brightcove, Inc. All rights reserved.
 //
 
-import AdSupport
+/*
+ * This sample app shows how to play IMA ads with Apple's native
+ * `AVPlayerViewController` transport controls on tvOS.
+ *
+ * A VMAP ad tag is attached to the `BCOVVideo` under `kBCOVIMAAdTag`, so the
+ * BCOVIMA plugin schedules the ad breaks. The native playback controls are
+ * hidden while an ad sequence plays and restored when it ends, and the video's
+ * title, description, and poster are surfaced in the tvOS Info panel as
+ * external metadata.
+ */
+
 import AppTrackingTransparency
 import UIKit
 import GoogleInteractiveMediaAds
@@ -29,13 +39,13 @@ final class ViewController: UIViewController {
         return .init(withRequestFactory: factory)
     }()
 
-    fileprivate lazy var avpvc: AVPlayerViewController = {
-        let avpvc = AVPlayerViewController()
-        addChild(avpvc)
-        view.addSubview(avpvc.view)
-        avpvc.view.frame = view.bounds
-        avpvc.didMove(toParent: self)
-        return avpvc
+    fileprivate lazy var playerViewController: AVPlayerViewController = {
+        let playerViewController = AVPlayerViewController()
+        addChild(playerViewController)
+        view.addSubview(playerViewController.view)
+        playerViewController.view.frame = view.bounds
+        playerViewController.didMove(toParent: self)
+        return playerViewController
     }()
 
     fileprivate lazy var playbackController: BCOVPlaybackController? = {
@@ -47,7 +57,7 @@ final class ViewController: UIViewController {
                                                            upstreamSessionProvider: nil)
 
         let imaSettings = IMASettings()
-        imaSettings.language = NSLocale.current.languageCode!
+        imaSettings.language = NSLocale.current.languageCode ?? "en"
 
         let renderSettings = IMAAdsRenderingSettings()
         renderSettings.linkOpenerPresentingController = self
@@ -62,8 +72,8 @@ final class ViewController: UIViewController {
         guard let imaSessionProvider = sdkManager.createIMASessionProvider(with: imaSettings,
                                                                            adsRenderingSettings: renderSettings,
                                                                            adsRequestPolicy: adsRequestPolicy,
-                                                                           adContainer: avpvc.contentOverlayView,
-                                                                           viewController: avpvc,
+                                                                           adContainer: playerViewController.contentOverlayView,
+                                                                           viewController: playerViewController,
                                                                            companionSlots: nil,
                                                                            upstreamSessionProvider: fps,
                                                                            options: imaPlaybackSessionOptions) else {
@@ -96,28 +106,12 @@ final class ViewController: UIViewController {
     @objc
     fileprivate func requestTrackingAuthorization() {
         if #available(tvOS 14.5, *) {
-            ATTrackingManager.requestTrackingAuthorization { status in
-                switch (status) {
-                    case .authorized:
-                        print("Authorized Tracking Permission")
-                    case .denied:
-                        print("Denied Tracking Permission")
-                    case .notDetermined:
-                        print("Not Determined Tracking Permission")
-                    case .restricted:
-                        print("Restricted Tracking Permission")
-                    @unknown default:
-                        print("Default value Trackin Permission")
-                }
-
-                print("IDFA: \(ASIdentifierManager.shared().advertisingIdentifier.uuidString)")
-
+            ATTrackingManager.requestTrackingAuthorization { _ in
                 DispatchQueue.main.async { [self] in
                     // Tracking authorization completed.
                     // Start loading ads here.
                     requestContentFromPlaybackService()
                 }
-
             }
         } else {
             requestContentFromPlaybackService()
@@ -132,10 +126,11 @@ final class ViewController: UIViewController {
         let configuration = [BCOVPlaybackService.ConfigurationKeyAssetID: kVideoId]
         playbackService.findVideo(withConfiguration: configuration,
                                   queryParameters: nil) {
-            [self] (video: BCOVVideo?,
-                    jsonResponse: Any?,
-                    error: Error?) in
-            guard let video,
+            [weak self] (video: BCOVVideo?,
+                         jsonResponse: Any?,
+                         error: Error?) in
+            guard let self,
+                  let video,
                   let playbackController else {
                 if let error {
                     print("ViewController - Error retrieving video: \(error.localizedDescription)")
@@ -160,8 +155,8 @@ final class ViewController: UIViewController {
 
                 alert.addAction(.init(title: "OK", style: .default))
 
-                DispatchQueue.main.async { [self] in
-                    present(alert, animated: true)
+                DispatchQueue.main.async {
+                    self.present(alert, animated: true)
                 }
 
                 return
@@ -235,8 +230,6 @@ extension ViewController: BCOVPlaybackControllerDelegate {
 
     func playbackController(_ controller: BCOVPlaybackController!,
                             didAdvanceTo session: BCOVPlaybackSession!) {
-        print("ViewController - Advanced to new session.")
-
         guard let video = session.video,
               let player = session.player,
               let currentItem = player.currentItem else {
@@ -249,31 +242,29 @@ extension ViewController: BCOVPlaybackControllerDelegate {
         }
 
         // Set the player on the AVPlayerViewController to begin playback
-        avpvc.player = player
+        playerViewController.player = player
     }
 
     func playbackController(_ controller: BCOVPlaybackController!,
-                            playbackSession session: BCOVPlaybackSession,
+                            playbackSession session: BCOVPlaybackSession!,
                             didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {
 
         if kBCOVPlaybackSessionLifecycleEventFail == lifecycleEvent.eventType,
-           let error = lifecycleEvent.properties["error"] as? NSError {
+           let error = lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError] as? NSError {
             // Report any errors that may have occurred with playback.
             print("ViewController - Playback error: \(error.localizedDescription)")
         }
 
         // Ad events are emitted by the BCOVIMA plugin through lifecycle events.
-        // The events are defined BCOVIMAComponent.h.
+        // The events are defined in BCOVIMAComponent.h.
         if kBCOVIMALifecycleEventAdsLoaderLoaded == lifecycleEvent.eventType,
            let adsManager = lifecycleEvent.properties[kBCOVIMALifecycleEventPropertyKeyAdsManager] as? IMAAdsManager {
-            print("ViewController - Ads loaded.")
-
             // Lower the volume of ads by half.
             adsManager.volume = adsManager.volume / 2.0
             print("ViewController - IMAAdsManager.volume set to \(String(format: "%0.1f", adsManager.volume))")
 
         } else if kBCOVIMALifecycleEventAdsManagerDidReceiveAdEvent == lifecycleEvent.eventType,
-                  let adEvent = lifecycleEvent.properties["adEvent"] as? IMAAdEvent {
+                  let adEvent = lifecycleEvent.properties[kBCOVIMALifecycleEventPropertyKeyAdEvent] as? IMAAdEvent {
             switch adEvent.type {
                 case .STARTED:
                     print("ViewController - Ad Started.")
@@ -296,15 +287,13 @@ extension ViewController: BCOVPlaybackControllerAdsDelegate {
     func playbackController(_ controller: BCOVPlaybackController,
                             playbackSession session: BCOVPlaybackSession,
                             didEnterAdSequence adSequence: BCOVAdSequence) {
-        print("ViewController - Entering ad sequence")
-        avpvc.showsPlaybackControls = false
+        playerViewController.showsPlaybackControls = false
     }
 
     func playbackController(_ controller: BCOVPlaybackController,
                             playbackSession session: BCOVPlaybackSession,
                             didExitAdSequence adSequence: BCOVAdSequence) {
-        print("ViewController - Exiting ad sequence")
-        avpvc.showsPlaybackControls = true
+        playerViewController.showsPlaybackControls = true
     }
 
     func playbackController(_ controller: BCOVPlaybackController,

--- a/Offline/OfflinePlayer/AppDelegate.swift
+++ b/Offline/OfflinePlayer/AppDelegate.swift
@@ -9,7 +9,7 @@ import AVFoundation
 import UIKit
 
 
-@UIApplicationMain
+@main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/Offline/OfflinePlayer/BCOVOfflineVideoStatus+Extensions.swift
+++ b/Offline/OfflinePlayer/BCOVOfflineVideoStatus+Extensions.swift
@@ -17,7 +17,7 @@ extension BCOVOfflineVideoStatus {
         return BCOVOfflineVideoManager.sharedManager?.videoObject(fromOfflineVideoToken: offlineVideoToken)
     }
 
-    var infoForDonwloadState: String {
+    var infoForDownloadState: String {
         switch (downloadState) {
             case .requested:
                 return "download requested"

--- a/Offline/OfflinePlayer/BCOVOfflineVideoStatus+Extensions.swift
+++ b/Offline/OfflinePlayer/BCOVOfflineVideoStatus+Extensions.swift
@@ -23,7 +23,10 @@ extension BCOVOfflineVideoStatus {
                 return "download requested"
 
             case .downloading:
-                let actualMegabytes = UIDevice.current.usedDiskSpace(forVideo: offlineVideo!)
+                guard let offlineVideo else {
+                    return String(format: "downloading\nProgress: %0.2f%%", downloadPercent)
+                }
+                let actualMegabytes = UIDevice.current.usedDiskSpace(forVideo: offlineVideo)
                 let totalDownloadTime = Date.timeIntervalSinceReferenceDate - (downloadStartTime?.timeIntervalSinceReferenceDate ?? 0)
                 let mbps = (actualMegabytes * downloadPercent / 100) / totalDownloadTime
                 let speed = String(format: "%0.2f %@", (mbps < 0.5 ? mbps * 1000 : mbps), (mbps < 0.5 ? "KB/s" : "MB/s"))
@@ -37,7 +40,10 @@ extension BCOVOfflineVideoStatus {
                 return "cancelled"
 
             case .completed:
-                let actualMegabytes = UIDevice.current.usedDiskSpace(forVideo: offlineVideo!)
+                guard let offlineVideo else {
+                    return "complete"
+                }
+                let actualMegabytes = UIDevice.current.usedDiskSpace(forVideo: offlineVideo)
                 let totalDownloadTime = (downloadEndTime?.timeIntervalSinceReferenceDate ?? .infinity) - (downloadStartTime?.timeIntervalSinceReferenceDate ?? 0)
                 let mbps = actualMegabytes / totalDownloadTime
                 let speed = String(format: "%0.2f %@", (mbps < 0.5 ? mbps * 1000 : mbps), (mbps < 0.5 ? "KB/s" : "MB/s"))

--- a/Offline/OfflinePlayer/DownloadManager.swift
+++ b/Offline/OfflinePlayer/DownloadManager.swift
@@ -12,19 +12,22 @@ import BrightcovePlayerSDK
 
 struct VideoDownload {
     let video: BCOVVideo
-    let paramaters: [String: Any]
+    let parameters: [String: Any]
 }
 
 
 final class DownloadManager: NSObject {
 
-    static var shared = DownloadManager()
+    static let shared = DownloadManager()
 
     class var downloadParameters: [String: Any] {
         // Get base license parameters
         var downloadParameters = DownloadManager.licenseParameters
 
-        guard let window = UIApplication.shared.keyWindow,
+        guard let window = UIApplication.shared.connectedScenes
+                .compactMap({ $0 as? UIWindowScene })
+                .flatMap(\.windows)
+                .first(where: \.isKeyWindow),
               let rootViewController = window.rootViewController as? UITabBarController,
               let settingsViewController = rootViewController.settingsViewController else {
             return downloadParameters
@@ -33,21 +36,22 @@ final class DownloadManager: NSObject {
         // Add bitrate parameter for the primary download
         let bitrate = settingsViewController.bitrate
 
-        print("Requested bitrate: \(bitrate)")
-
         downloadParameters[BCOVOfflineVideoManager.RequestedBitrateKey] = bitrate
 
         return downloadParameters
     }
 
-    class var licenseParameters: [String: Any]  {
-        guard let window = UIApplication.shared.keyWindow,
+    class var licenseParameters: [String: Any] {
+        guard let window = UIApplication.shared.connectedScenes
+                .compactMap({ $0 as? UIWindowScene })
+                .flatMap(\.windows)
+                .first(where: \.isKeyWindow),
               let rootViewController = window.rootViewController as? UITabBarController,
               let settingsViewController = rootViewController.settingsViewController else {
             return .init()
         }
 
-        var licenseParamaters: [String: Any] = .init()
+        var licenseParameters: [String: Any] = .init()
 
         // Generate the license parameters based on the Settings tab
         let isPurchaseLicense = settingsViewController.purchaseLicenseType
@@ -55,25 +59,23 @@ final class DownloadManager: NSObject {
         // It's harmless to add it for non-FairPlay videos too.
 
         if isPurchaseLicense {
-            print("Requesting Purchase License")
-            licenseParamaters[BCOVFairPlayLicense.PurchaseKey] = true
+            licenseParameters[BCOVFairPlayLicense.PurchaseKey] = true
         } else {
             let rentalDuration = settingsViewController.rentalDuration
             let playDuration = settingsViewController.playDuration
 
-            print("Requesting Rental License\nrentalDuration: \(rentalDuration)\nplayDuration: \(playDuration)")
-            licenseParamaters[BCOVFairPlayLicense.RentalDurationKey] = rentalDuration
-            licenseParamaters[BCOVFairPlayLicense.PlayDurationKey] = playDuration
+            licenseParameters[BCOVFairPlayLicense.RentalDurationKey] = rentalDuration
+            licenseParameters[BCOVFairPlayLicense.PlayDurationKey] = playDuration
         }
 
-        return licenseParamaters
+        return licenseParameters
     }
 
     // The download queue.
     // Videos go into the preload queue first.
     // When all preloads are done, videos move to the download queue.
-    fileprivate lazy var videoPreloadQueue: [VideoDownload] = .init()
-    fileprivate lazy var videoDownloadQueue: [VideoDownload] = .init()
+    fileprivate var videoPreloadQueue: [VideoDownload] = .init()
+    fileprivate var videoDownloadQueue: [VideoDownload] = .init()
 
     func doDownload(forVideo video: BCOVVideo) {
         if videoAlreadyProcessing(video) {
@@ -81,7 +83,7 @@ final class DownloadManager: NSObject {
         }
 
         let videoDownload = VideoDownload(video: video,
-                                          paramaters: DownloadManager.downloadParameters)
+                                          parameters: DownloadManager.downloadParameters)
 
         videoPreloadQueue.append(videoDownload)
 
@@ -137,7 +139,6 @@ final class DownloadManager: NSObject {
                                                actionTitle: "Retry",
                                                cancelTitle: "Cancel") {
 
-                        print("Deleting previous download for video and attempting again.")
                         offlineManager.deleteOfflineVideo(offlineVideoToken)
                         DownloadManager.shared.doDownload(forVideo: video)
                     }
@@ -171,8 +172,6 @@ final class DownloadManager: NSObject {
         // If there's no FairPlay involved, the video is moved on
         // to the video download queue.
         if !videoDownload.video.usesFairPlay {
-            print("Video \"\(videoDownload.video.localizedName ?? "unknown")\" does not use FairPlay; preloading not necessary")
-
             videoDownloadQueue.append(videoDownload)
 
             DispatchQueue.main.async { [self] in
@@ -187,7 +186,7 @@ final class DownloadManager: NSObject {
             }
 
             offlineManager.preloadFairPlayLicense(videoDownload.video,
-                                                  parameters: videoDownload.paramaters) {
+                                                  parameters: videoDownload.parameters) {
                 (offlineVideoToken: String?, error: Error?) in
 
                 DispatchQueue.main.async { [weak self] in
@@ -280,7 +279,7 @@ final class DownloadManager: NSObject {
 
         offlineManager.requestVideoDownload(videoDownload.video,
                                             mediaSelections: mediaSelections,
-                                            parameters: videoDownload.paramaters) {
+                                            parameters: videoDownload.parameters) {
             (offlineVideoToken: String?, error: Error?) in
 
             DispatchQueue.main.async {
@@ -308,24 +307,6 @@ final class DownloadManager: NSObject {
         let audibleDisplayName = mediaSelection.selectedMediaOption(in: audibleMSG)?.displayName ?? "-"
 
         return "MediaSelection(obj:\(mediaSelection), legible:\(legibleDisplayName), audible:\(audibleDisplayName))"
-    }
-
-    fileprivate class func mediaSelectionDescription(from mediaSelection: AVMediaSelection,
-                                                     for token: BCOVOfflineVideoToken) -> String {
-
-        // Get the offline video object and its path
-        guard let offlineManager = BCOVOfflineVideoManager.sharedManager,
-              let video = offlineManager.videoObject(fromOfflineVideoToken: token),
-              let videoPath = video.properties[BCOVOfflineVideo.FilePathPropertyKey] as? String else {
-            return "MediaSelection(n/a)"
-        }
-
-        let videoPathURL = URL(fileURLWithPath: videoPath)
-        let urlAsset = AVURLAsset(url: videoPathURL)
-        let desc = DownloadManager.mediaSelectionDescription(from: mediaSelection,
-                                                             with: urlAsset)
-
-        return desc
     }
 }
 

--- a/Offline/OfflinePlayer/DownloadManager.swift
+++ b/Offline/OfflinePlayer/DownloadManager.swift
@@ -77,6 +77,10 @@ final class DownloadManager: NSObject {
     fileprivate var videoPreloadQueue: [VideoDownload] = .init()
     fileprivate var videoDownloadQueue: [VideoDownload] = .init()
 
+    // Serializes all access to `videoPreloadQueue` and `videoDownloadQueue`,
+    // which are read and mutated from both the main queue and a background queue.
+    private let queueAccess = DispatchQueue(label: "com.brightcove.offlineplayer.download-queue")
+
     func doDownload(forVideo video: BCOVVideo) {
         if videoAlreadyProcessing(video) {
             return
@@ -85,7 +89,9 @@ final class DownloadManager: NSObject {
         let videoDownload = VideoDownload(video: video,
                                           parameters: DownloadManager.downloadParameters)
 
-        videoPreloadQueue.append(videoDownload)
+        queueAccess.sync {
+            videoPreloadQueue.append(videoDownload)
+        }
 
         DispatchQueue.main.async { [self] in
             runPreloadVideoQueue()
@@ -96,7 +102,8 @@ final class DownloadManager: NSObject {
         // First check to see if the video is in a preload queue
         // videoPreloadQueue is an array of NSDictionary objects,
         // with a BCOVVideo under each "video" key.
-        for videoDict in videoPreloadQueue {
+        let preloadQueue = queueAccess.sync { videoPreloadQueue }
+        for videoDict in preloadQueue {
             if videoDict.video.matches(with: video) {
                 UIAlertController.showWith(title: "Video Already in Preload Queue",
                                            message: "The video \(video.localizedName ?? "unknown") is already queued to be preloaded")
@@ -107,7 +114,8 @@ final class DownloadManager: NSObject {
 
         // First check to see if the video is in a download queue
         // videoDownloadQueue is an array of BCOVVideo objects
-        for videoDict in videoDownloadQueue {
+        let downloadQueue = queueAccess.sync { videoDownloadQueue }
+        for videoDict in downloadQueue {
             if videoDict.video.matches(with: video) {
                 UIAlertController.showWith(title: "Video Already in Download Queue",
                                            message: "The video \(video.localizedName ?? "unknown") is already queued to be downloaded")
@@ -156,7 +164,19 @@ final class DownloadManager: NSObject {
     }
 
     fileprivate func runPreloadVideoQueue() {
-        guard let videoDownload = videoPreloadQueue.first else {
+        let videoDownload: VideoDownload? = queueAccess.sync { () -> VideoDownload? in
+            guard let videoDownload = videoPreloadQueue.first else {
+                return nil
+            }
+
+            if let indexOfVideo = videoPreloadQueue.firstIndex(where: { $0.video.matches(with: videoDownload.video) }) {
+                videoPreloadQueue.remove(at: indexOfVideo)
+            }
+
+            return videoDownload
+        }
+
+        guard let videoDownload else {
             DispatchQueue.global(qos: .background).async { [self] in
                 downloadVideoFromQueue()
             }
@@ -164,15 +184,13 @@ final class DownloadManager: NSObject {
             return
         }
 
-        if let indexOfVideo = videoPreloadQueue.firstIndex(where: { $0.video.matches(with: videoDownload.video) }) {
-            videoPreloadQueue.remove(at: indexOfVideo)
-        }
-
         // Preloading only applies to FairPlay-protected videos.
         // If there's no FairPlay involved, the video is moved on
         // to the video download queue.
         if !videoDownload.video.usesFairPlay {
-            videoDownloadQueue.append(videoDownload)
+            queueAccess.sync {
+                videoDownloadQueue.append(videoDownload)
+            }
 
             DispatchQueue.main.async { [self] in
                 runPreloadVideoQueue()
@@ -201,7 +219,9 @@ final class DownloadManager: NSObject {
                             print("Preloaded \(offlineVideoToken)")
                         }
 
-                        videoDownloadQueue.append(videoDownload)
+                        queueAccess.sync {
+                            self.videoDownloadQueue.append(videoDownload)
+                        }
                     }
 
                     runPreloadVideoQueue()
@@ -214,12 +234,20 @@ final class DownloadManager: NSObject {
     }
 
     fileprivate func downloadVideoFromQueue() {
-        guard let videoDownload = videoDownloadQueue.first else {
-            return
+        let videoDownload: VideoDownload? = queueAccess.sync { () -> VideoDownload? in
+            guard let videoDownload = videoDownloadQueue.first else {
+                return nil
+            }
+
+            if let indexOfVideo = videoDownloadQueue.firstIndex(where: { $0.video.matches(with: videoDownload.video) }) {
+                videoDownloadQueue.remove(at: indexOfVideo)
+            }
+
+            return videoDownload
         }
 
-        if let indexOfVideo = videoDownloadQueue.firstIndex(where: { $0.video.matches(with: videoDownload.video) }) {
-            videoDownloadQueue.remove(at: indexOfVideo)
+        guard let videoDownload else {
+            return
         }
 
         guard let offlineManager = BCOVOfflineVideoManager.sharedManager else {

--- a/Offline/OfflinePlayer/DownloadsViewController.swift
+++ b/Offline/OfflinePlayer/DownloadsViewController.swift
@@ -213,7 +213,7 @@ final class DownloadsViewController: UIViewController {
     }
 
     // The offline video token playing in the video view
-    fileprivate var currentlyPlayingOfflineVideoToken: BCOVOfflineVideoToken? = .init()
+    fileprivate var currentlyPlayingOfflineVideoToken: BCOVOfflineVideoToken? = nil
 
     fileprivate var freeSpaceTimer: Timer?
 
@@ -261,17 +261,17 @@ final class DownloadsViewController: UIViewController {
 
     @objc
     fileprivate func updateStatus(_ notification: NSNotification) {
-        guard isVisible,
-              let offlineManager = BCOVOfflineVideoManager.sharedManager else {
-            tableView.reloadData()
-            return
-        }
-
-        let offlineVideoStatusArray = offlineManager.offlineVideoStatus()
-
-        let offlineVideoTokens = offlineManager.offlineVideoTokens
-
         DispatchQueue.main.async { [self] in
+            guard isVisible,
+                  let offlineManager = BCOVOfflineVideoManager.sharedManager else {
+                tableView.reloadData()
+                return
+            }
+
+            let offlineVideoStatusArray = offlineManager.offlineVideoStatus()
+
+            let offlineVideoTokens = offlineManager.offlineVideoTokens
+
             if let video = notification.object as? BCOVVideo,
                let offlineVideoToken = video.offlineVideoToken as? BCOVOfflineVideoToken,
                let offlineVideoTokenIndex = offlineVideoTokens.firstIndex(where: { $0 == offlineVideoToken }) {
@@ -303,10 +303,10 @@ final class DownloadsViewController: UIViewController {
     @objc
     fileprivate func updateFreeSpaceLabel() {
         if let freeDiskSpace = Double(UIDevice.current.freeDiskSpace) {
-            if freeDiskSpace < 50 {
-                freeSpaceLabel.textColor = .systemOrange
-            } else if freeDiskSpace < 10 {
+            if freeDiskSpace < 10 {
                 freeSpaceLabel.textColor = .systemRed
+            } else if freeDiskSpace < 50 {
+                freeSpaceLabel.textColor = .systemOrange
             } else {
                 freeSpaceLabel.textColor = .systemGray
             }

--- a/Offline/OfflinePlayer/DownloadsViewController.swift
+++ b/Offline/OfflinePlayer/DownloadsViewController.swift
@@ -97,7 +97,7 @@ final class DownloadsViewController: UIViewController {
         }
     }
 
-    @IBOutlet  fileprivate weak var footerTableView: UIView! {
+    @IBOutlet fileprivate weak var footerTableView: UIView! {
         didSet {
             footerTableView.layer.borderColor = UIColor.init(white: 0.9,
                                                              alpha: 1.0).cgColor
@@ -202,7 +202,7 @@ final class DownloadsViewController: UIViewController {
     }()
 
     // The offline video token of the video selected in the table
-    fileprivate lazy var selectedOfflineVideoToken: BCOVOfflineVideoToken? = nil {
+    fileprivate var selectedOfflineVideoToken: BCOVOfflineVideoToken? {
         didSet {
             resetVideoContainer()
 
@@ -213,11 +213,11 @@ final class DownloadsViewController: UIViewController {
     }
 
     // The offline video token playing in the video view
-    fileprivate lazy var currentlyPlayingOfflineVideoToken: BCOVOfflineVideoToken? = .init()
+    fileprivate var currentlyPlayingOfflineVideoToken: BCOVOfflineVideoToken? = .init()
 
     fileprivate var freeSpaceTimer: Timer?
 
-    fileprivate lazy var statusBarHidden = false {
+    fileprivate var statusBarHidden = false {
         didSet {
             if let tabBarController {
                 tabBarController.tabBar.isHidden = statusBarHidden
@@ -348,7 +348,7 @@ final class DownloadsViewController: UIViewController {
             posterImageView.image = UIImage(named: "AppIcon")
         }
 
-        infoLabel.text = "\(video.localizedName ?? "unknown")\nLicense: \(video.license)\nStatus: \(offlineVideoStatus.infoForDonwloadState)"
+        infoLabel.text = "\(video.localizedName ?? "unknown")\nLicense: \(video.license)\nStatus: \(offlineVideoStatus.infoForDownloadState)"
         infoLabel.sizeToFit()
     }
 
@@ -415,11 +415,11 @@ final class DownloadsViewController: UIViewController {
             }
 
             if let video {
-                let licenseParamaters = DownloadManager.licenseParameters
+                let licenseParameters = DownloadManager.licenseParameters
 
                 offlineManager.renewFairPlayLicense(offlineVideoToken,
                                                     video: video,
-                                                    parameters: licenseParamaters) {
+                                                    parameters: licenseParameters) {
                     (offlineVideoToken: BCOVOfflineVideoToken?, error: Error?) in
 
                     if let error {
@@ -616,15 +616,6 @@ final class DownloadsViewController: UIViewController {
 // MARK: - BCOVPlaybackControllerDelegate
 
 extension DownloadsViewController: BCOVPlaybackControllerDelegate {
-
-    func playbackController(_ controller: BCOVPlaybackController!,
-                            didAdvanceTo session: BCOVPlaybackSession!) {
-        print("ViewController - Advanced to new session.")
-
-        if let source = session.source {
-            print("Session source details: \(source)")
-        }
-    }
 
     func playbackController(_ controller: BCOVPlaybackController!,
                             playbackSession session: BCOVPlaybackSession!,

--- a/Offline/OfflinePlayer/UIAlertController+Extensions.swift
+++ b/Offline/OfflinePlayer/UIAlertController+Extensions.swift
@@ -42,7 +42,10 @@ extension UIAlertController {
                                           handler: nil))
         }
 
-        guard let window = UIApplication.shared.keyWindow,
+        guard let window = UIApplication.shared.connectedScenes
+                .compactMap({ $0 as? UIWindowScene })
+                .flatMap(\.windows)
+                .first(where: \.isKeyWindow),
               let rootViewController = window.rootViewController else {
             return
         }

--- a/Offline/OfflinePlayer/UITableViewCell+Extensions.swift
+++ b/Offline/OfflinePlayer/UITableViewCell+Extensions.swift
@@ -15,7 +15,7 @@ extension UITableViewCell {
         var parentResponder: UIResponder? = self
 
         while parentResponder != nil {
-            parentResponder = parentResponder!.next
+            parentResponder = parentResponder?.next
             if let viewController = parentResponder as? UIViewController {
                 return viewController
             }

--- a/Offline/OfflinePlayer/VideoManager.swift
+++ b/Offline/OfflinePlayer/VideoManager.swift
@@ -19,7 +19,7 @@ let kPlaylistRefId = "brightcove-native-sdk-plist"
 
 final class VideoManager: NSObject {
 
-    static var shared = VideoManager()
+    static let shared = VideoManager()
 
     fileprivate lazy var playbackService: BCOVPlaybackService = {
         let factory = BCOVPlaybackServiceRequestFactory(withAccountId: kAccountId,
@@ -27,9 +27,9 @@ final class VideoManager: NSObject {
         return .init(withRequestFactory: factory)
     }()
 
-    fileprivate(set) lazy var videos: [BCOVVideo] = .init()
-    fileprivate(set) lazy var thumbnails: [String: UIImage] = .init()
-    fileprivate(set) lazy var downloadSize: [String: Double] = .init()
+    fileprivate(set) var videos: [BCOVVideo] = .init()
+    fileprivate(set) var thumbnails: [String: UIImage] = .init()
+    fileprivate(set) var downloadSize: [String: Double] = .init()
 
     func retrievePlaylist(with configuration: [String: Any],
                           queryParameters: [String: Any]?,

--- a/Offline/OfflinePlayer/VideoTableViewCell.swift
+++ b/Offline/OfflinePlayer/VideoTableViewCell.swift
@@ -10,7 +10,7 @@ import UIKit
 import BrightcovePlayerSDK
 
 
-protocol VideoTableViewCellDelegate: class {
+protocol VideoTableViewCellDelegate: AnyObject {
     func performDownload(forVideo video: BCOVVideo)
 }
 
@@ -43,7 +43,7 @@ final class VideoTableViewCell: UITableViewCell {
                let offlineManager = BCOVOfflineVideoManager.sharedManager,
                let offlineVideoStatus = offlineManager.offlineVideoStatus(forToken: offlineVideoToken) {
                 progressView.isHidden = offlineVideoStatus.downloadState == .completed
-                progressView.progress =  Float(offlineVideoStatus.downloadPercent / 100.0)
+                progressView.progress = Float(offlineVideoStatus.downloadPercent / 100.0)
             }
 
             accessoryView = !(UIDevice.current.isSimulator && video.usesFairPlay) ? actionAccessoryView : nil

--- a/Offline/OfflinePlayer/VideosViewController.swift
+++ b/Offline/OfflinePlayer/VideosViewController.swift
@@ -5,6 +5,23 @@
 //  Copyright © 2026 Brightcove, Inc. All rights reserved.
 //
 
+/*
+ * This sample app shows how to download Video Cloud videos, including
+ * FairPlay-protected content, for offline playback using
+ * `BCOVOfflineVideoManager`.
+ *
+ * The app has three tabs: Videos (this controller) browses the playlist and
+ * lets the user queue downloads; Downloads manages and plays downloaded videos;
+ * Settings configures the requested bitrate and the FairPlay license type
+ * (rental or purchase).
+ *
+ * This controller initializes the shared `BCOVOfflineVideoManager` in
+ * `viewDidLoad`, loads the playlist, and hands off download requests to
+ * `DownloadManager`. FairPlay-protected videos preload their license before the
+ * media is downloaded, and FairPlay content only plays on physical devices, not
+ * the simulator.
+ */
+
 import UIKit
 
 import BrightcovePlayerSDK
@@ -137,7 +154,7 @@ final class VideosViewController: UIViewController {
         return refreshControl
     }()
 
-    fileprivate lazy var statusBarHidden = false {
+    fileprivate var statusBarHidden = false {
         didSet {
             if let tabBarController {
                 tabBarController.tabBar.isHidden = statusBarHidden
@@ -251,15 +268,6 @@ final class VideosViewController: UIViewController {
 extension VideosViewController: BCOVPlaybackControllerDelegate {
 
     func playbackController(_ controller: BCOVPlaybackController!,
-                            didAdvanceTo session: BCOVPlaybackSession!) {
-        print("ViewController - Advanced to new session.")
-
-        if let source = session.source {
-            print("Session source details: \(source)")
-        }
-    }
-
-    func playbackController(_ controller: BCOVPlaybackController!,
                             playbackSession session: BCOVPlaybackSession!,
                             didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {
 
@@ -268,7 +276,7 @@ extension VideosViewController: BCOVPlaybackControllerDelegate {
         }
 
         // Report any errors that may have occurred with playback.
-        print("ViewController - Playback error: \(error.localizedDescription)")
+        print("VideosViewController - Playback error: \(error.localizedDescription)")
     }
 }
 

--- a/Player/AppleTV-tvOS/AppleTV/AppDelegate.swift
+++ b/Player/AppleTV-tvOS/AppleTV/AppDelegate.swift
@@ -9,7 +9,7 @@ import AVFoundation
 import UIKit
 
 
-@UIApplicationMain
+@main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/Player/AppleTV-tvOS/AppleTV/SampleInfoViewController.swift
+++ b/Player/AppleTV-tvOS/AppleTV/SampleInfoViewController.swift
@@ -12,20 +12,20 @@ final class SampleInfoViewController: UIViewController, BCOVPlaybackSessionConsu
 
     fileprivate weak var playerView: BCOVTVPlayerView?
 
-    fileprivate lazy var button1: UIButton = {
-        let button = UIButton.init(type: .system)
-        button.frame = CGRect.init(x:20, y:40, width:280, height:80)
-        button.setTitle("Button 1", for:.normal)
+    fileprivate lazy var firstButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.frame = CGRect(x: 20, y: 40, width: 280, height: 80)
+        button.setTitle("Button 1", for: .normal)
         button.addTarget(self,
                          action: #selector(buttonHandler),
                          for: .primaryActionTriggered)
         return button
     }()
 
-    fileprivate lazy var button2: UIButton = {
-        let button = UIButton.init(type: .system)
-        button.frame = CGRect.init(x:340, y:40, width:280, height:80)
-        button.setTitle("Button 2", for:.normal)
+    fileprivate lazy var secondButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.frame = CGRect(x: 340, y: 40, width: 280, height: 80)
+        button.setTitle("Button 2", for: .normal)
         button.addTarget(self,
                          action: #selector(buttonHandler),
                          for: .primaryActionTriggered)
@@ -42,8 +42,8 @@ final class SampleInfoViewController: UIViewController, BCOVPlaybackSessionConsu
 
         title = "Sample"
 
-        view.addSubview(button1)
-        view.addSubview(button2)
+        view.addSubview(firstButton)
+        view.addSubview(secondButton)
     }
 
     @objc
@@ -53,15 +53,13 @@ final class SampleInfoViewController: UIViewController, BCOVPlaybackSessionConsu
             return
         }
 
-        print("\(text) triggered")
-
         // Show a large label in the middle of the screen and fade it away.
         let fadingLabel: UILabel = {
-            let label: UILabel = .init(frame: CGRect.init(x:0, y:0, width:840, height:140))
+            let label: UILabel = .init(frame: CGRect(x: 0, y: 0, width: 840, height: 140))
             label.clipsToBounds = true
             label.textColor = .red
-            label.textAlignment = NSTextAlignment.center
-            label.backgroundColor = UIColor.init(white: 0.0, alpha: 0.4)
+            label.textAlignment = .center
+            label.backgroundColor = UIColor(white: 0.0, alpha: 0.4)
             label.font = UIFont.boldSystemFont(ofSize: 72.0)
             label.text = "\(text) Clicked"
             label.center = playerView.center

--- a/Player/AppleTV-tvOS/AppleTV/ViewController.swift
+++ b/Player/AppleTV-tvOS/AppleTV/ViewController.swift
@@ -40,7 +40,7 @@ final class ViewController: UIViewController {
         playerView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
 
         let sampleInfoVC = SampleInfoViewController(playerView: playerView)
-        sampleInfoVC.preferredContentSize = CGSizeMake(0, 200)
+        sampleInfoVC.preferredContentSize = CGSize(width: 0, height: 200)
         playerView.controlsView.customInfoViewControllers = [sampleInfoVC]
 
         view.addSubview(playerView)
@@ -57,7 +57,7 @@ final class ViewController: UIViewController {
         let fps = sdkManager.createFairPlaySessionProvider(withApplicationCertificate: nil,
                                                            authorizationProxy: authProxy,
                                                            upstreamSessionProvider: nil)
-        guard let playerView else{
+        guard let playerView else {
             return nil
         }
 
@@ -129,16 +129,11 @@ final class ViewController: UIViewController {
 extension ViewController: BCOVPlaybackControllerDelegate {
 
     func playbackController(_ controller: BCOVPlaybackController!,
-                            didAdvanceTo session: BCOVPlaybackSession!) {
-        print("ViewController - Advanced to new session.")
-    }
-
-    func playbackController(_ controller: BCOVPlaybackController!,
                             playbackSession session: BCOVPlaybackSession,
                             didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {
 
         if kBCOVPlaybackSessionLifecycleEventFail == lifecycleEvent.eventType,
-           let error = lifecycleEvent.properties["error"] as? NSError {
+           let error = lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError] as? NSError {
             // Report any errors that may have occurred with playback.
             print("ViewController - Playback error: \(error.localizedDescription)")
         }

--- a/Player/DVRLive/DVRLive/AppDelegate.swift
+++ b/Player/DVRLive/DVRLive/AppDelegate.swift
@@ -9,7 +9,7 @@ import AVFoundation
 import UIKit
 
 
-@UIApplicationMain
+@main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/Player/DVRLive/DVRLive/ViewController.swift
+++ b/Player/DVRLive/DVRLive/ViewController.swift
@@ -5,6 +5,19 @@
 //  Copyright © 2026 Brightcove, Inc. All rights reserved.
 //
 
+/*
+ * This sample app shows how to play a live HLS stream using the live / DVR
+ * control layout.
+ *
+ * The player view is given a controls view built with
+ * `BCOVPUIBasicControlView.withLiveDVRLayout()`, which presents the live-edge
+ * indicator and DVR scrubbing controls appropriate for a live stream.
+ *
+ * The video is built directly from a raw HLS URL with `BCOVSource` and
+ * `BCOVVideo` rather than being retrieved from the Playback Service, so set
+ * `kVideoURLString` to your own live HLS stream before running.
+ */
+
 import UIKit
 import BrightcovePlayerSDK
 
@@ -59,14 +72,14 @@ final class ViewController: UIViewController {
         return playbackController
     }()
 
-    fileprivate lazy var statusBarHidden = false {
+    fileprivate var statusBarHidden = false {
         didSet {
             setNeedsStatusBarAppearanceUpdate()
         }
     }
 
     override var prefersStatusBarHidden: Bool {
-        return statusBarHidden
+        statusBarHidden
     }
 
     override func viewDidLoad() {
@@ -118,16 +131,11 @@ final class ViewController: UIViewController {
 extension ViewController: BCOVPlaybackControllerDelegate {
 
     func playbackController(_ controller: BCOVPlaybackController!,
-                            didAdvanceTo session: BCOVPlaybackSession!) {
-        print("ViewController - Advanced to new session.")
-    }
-
-    func playbackController(_ controller: BCOVPlaybackController!,
                             playbackSession session: BCOVPlaybackSession,
                             didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {
 
         if kBCOVPlaybackSessionLifecycleEventFail == lifecycleEvent.eventType,
-           let error = lifecycleEvent.properties["error"] as? NSError {
+           let error = lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError] as? NSError {
             // Report any errors that may have occurred with playback.
             print("ViewController - Playback error: \(error.localizedDescription)")
         }

--- a/Player/NativeControls/NativeControls/AppDelegate.swift
+++ b/Player/NativeControls/NativeControls/AppDelegate.swift
@@ -9,7 +9,7 @@ import AVFoundation
 import UIKit
 
 
-@UIApplicationMain
+@main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/Player/NativeControls/NativeControls/ViewController.swift
+++ b/Player/NativeControls/NativeControls/ViewController.swift
@@ -5,6 +5,18 @@
 //  Copyright © 2026 Brightcove, Inc. All rights reserved.
 //
 
+/*
+ * This sample app shows how to play Video Cloud content using Apple's native
+ * `AVPlayerViewController` transport controls instead of the Brightcove
+ * `BCOVPUIPlayerView`.
+ *
+ * The `kBCOVAVPlayerViewControllerCompatibilityKey` playback-controller option
+ * stops the SDK from creating a redundant `AVPlayerLayer`, since
+ * `AVPlayerViewController` already provides one. Each time the controller
+ * advances to a new session, that session's `AVPlayer` is handed to the
+ * `AVPlayerViewController`.
+ */
+
 import AVKit
 import UIKit
 import BrightcovePlayerSDK
@@ -27,14 +39,14 @@ final class ViewController: UIViewController {
         return .init(withRequestFactory: factory)
     }()
 
-    fileprivate lazy var avpvc: AVPlayerViewController = {
-        let avpvc = AVPlayerViewController()
-        avpvc.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        avpvc.view.frame = videoContainerView.bounds
-        videoContainerView.addSubview(avpvc.view)
-        addChild(avpvc)
-        avpvc.didMove(toParent: self)
-        return avpvc
+    fileprivate lazy var playerViewController: AVPlayerViewController = {
+        let playerViewController = AVPlayerViewController()
+        playerViewController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        playerViewController.view.frame = videoContainerView.bounds
+        videoContainerView.addSubview(playerViewController.view)
+        addChild(playerViewController)
+        playerViewController.didMove(toParent: self)
+        return playerViewController
     }()
 
     fileprivate lazy var playbackController: BCOVPlaybackController? = {
@@ -117,16 +129,15 @@ extension ViewController: BCOVPlaybackControllerDelegate {
 
     func playbackController(_ controller: BCOVPlaybackController!,
                             didAdvanceTo session: BCOVPlaybackSession!) {
-        avpvc.player = session.player
-        print("ViewController - Advanced to new session.")
+        playerViewController.player = session.player
     }
 
     func playbackController(_ controller: BCOVPlaybackController!,
-                            playbackSession session: BCOVPlaybackSession,
+                            playbackSession session: BCOVPlaybackSession!,
                             didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {
 
         if kBCOVPlaybackSessionLifecycleEventFail == lifecycleEvent.eventType,
-           let error = lifecycleEvent.properties["error"] as? NSError {
+           let error = lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError] as? NSError {
             // Report any errors that may have occurred with playback.
             print("ViewController - Playback error: \(error.localizedDescription)")
         }

--- a/Player/TableViewPlayer/TableViewPlayer/AppDelegate.swift
+++ b/Player/TableViewPlayer/TableViewPlayer/AppDelegate.swift
@@ -9,7 +9,7 @@ import AVFoundation
 import UIKit
 
 
-@UIApplicationMain
+@main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/Player/TableViewPlayer/TableViewPlayer/ViewController.swift
+++ b/Player/TableViewPlayer/TableViewPlayer/ViewController.swift
@@ -5,6 +5,18 @@
 //  Copyright © 2026 Brightcove, Inc. All rights reserved.
 //
 
+/*
+ * This sample app shows how to play many videos at once in a `UITableView`,
+ * with one `BCOVPlaybackController` per cell loaded from a playlist.
+ *
+ * Running multiple players simultaneously is resource-intensive, so each
+ * controller limits its memory footprint through buffer optimization
+ * (`kBCOVBufferOptimizerMethodKey` with a 1–5 second window) and by disabling
+ * thumbnail seeking. Playback follows the scroll: videos play when the table
+ * stops scrolling and pause when it starts, and only one cell is unmuted at a
+ * time. Live videos are dropped from the list as their sessions advance.
+ */
+
 import UIKit
 import BrightcovePlayerSDK
 
@@ -34,8 +46,8 @@ final class ViewController: UITableViewController {
         return .init(withRequestFactory: factory)
     }()
 
-    fileprivate lazy var playbackConfigurations = [String: PlaybackConfiguration]()
-    fileprivate lazy var videos: [BCOVVideo]? = nil {
+    fileprivate var playbackConfigurations = [String: PlaybackConfiguration]()
+    fileprivate var videos: [BCOVVideo]? {
         didSet {
             guard let videos else { return }
 
@@ -77,7 +89,7 @@ final class ViewController: UITableViewController {
         }
     }
 
-    fileprivate lazy var isScrolling = false
+    fileprivate var isScrolling = false
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -91,9 +103,11 @@ final class ViewController: UITableViewController {
         let configuration = [ BCOVPlaybackService.ConfigurationKeyAssetID: kPlaylistId]
         playbackService.findPlaylist(withConfiguration: configuration,
                                      queryParameters: nil) {
-            [self] (playlist: BCOVPlaylist?,
-                    json: Any?,
-                    error: Error?) in
+            [weak self] (playlist: BCOVPlaylist?,
+                         json: Any?,
+                         error: Error?) in
+            guard let self else { return }
+
             guard let playlist else {
                 if let error {
                     print("ViewController - Error retrieving video playlist: \(error.localizedDescription)")
@@ -124,7 +138,7 @@ final class ViewController: UITableViewController {
 
 // MARK: - BCOVPlaybackControllerDelegate
 
-extension ViewController : BCOVPlaybackControllerDelegate {
+extension ViewController: BCOVPlaybackControllerDelegate {
 
     func playbackController(_ controller: BCOVPlaybackController!,
                             didAdvanceTo session: BCOVPlaybackSession!) {
@@ -155,7 +169,7 @@ extension ViewController {
 
     override func tableView(_ tableView: UITableView,
                             numberOfRowsInSection section: Int) -> Int {
-        guard let videos else { return 0}
+        guard let videos else { return 0 }
         return videos.count
     }
 

--- a/Player/VerticalPlayer/VerticalPlayer/AppDelegate.swift
+++ b/Player/VerticalPlayer/VerticalPlayer/AppDelegate.swift
@@ -9,7 +9,7 @@ import AVFoundation
 import UIKit
 
 
-@UIApplicationMain
+@main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/Player/VerticalPlayer/VerticalPlayer/BCOVPageViewController.swift
+++ b/Player/VerticalPlayer/VerticalPlayer/BCOVPageViewController.swift
@@ -5,6 +5,19 @@
 //  Copyright © 2026 Brightcove, Inc. All rights reserved.
 //
 
+/*
+ * This sample app shows how to build a vertical, full-screen paging video
+ * feed (in the style of TikTok or Reels) from a Video Cloud playlist.
+ *
+ * A `UIPageViewController` provides swipe paging and wraps around from the
+ * last video back to the first. Each page is a `VideoViewController` running
+ * its own `BCOVPlaybackController`, and each session uses a `.resizeAspectFill`
+ * video gravity so the video fills the screen.
+ *
+ * `-requestContentFromPlaybackService` loads the playlist and prefetches every
+ * video's poster image so it is cached before its page appears.
+ */
+
 import UIKit
 import BrightcovePlayerSDK
 
@@ -23,7 +36,7 @@ final class BCOVPageViewController: UIPageViewController {
         return .init(withRequestFactory: factory)
     }()
 
-    fileprivate lazy var videos: [BCOVVideo] = .init()
+    fileprivate var videos: [BCOVVideo] = []
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -41,12 +54,13 @@ final class BCOVPageViewController: UIPageViewController {
     fileprivate func requestContentFromPlaybackService() {
         let configuration = [ BCOVPlaybackService.ConfigurationKeyAssetID: kPlaylistId]
         playbackService.findPlaylist(withConfiguration: configuration, queryParameters: nil) {
-            [self] (playlist: BCOVPlaylist?,
-                    json: Any?,
-                    error: Error?) in
-            guard let playlist else {
+            [weak self] (playlist: BCOVPlaylist?,
+                         json: Any?,
+                         error: Error?) in
+            guard let self,
+                  let playlist else {
                 if let error {
-                    print("ViewController - Error retrieving video playlist: \(error.localizedDescription)")
+                    print("BCOVPageViewController - Error retrieving video playlist: \(error.localizedDescription)")
                 }
 
                 return
@@ -110,8 +124,6 @@ extension BCOVPageViewController: UIPageViewControllerDataSource {
             previousVideoIndex = currentVideoIndex - 1
         }
 
-        print("using video at index \(previousVideoIndex)")
-
         let video = videos[previousVideoIndex]
         videoVC.video = video
 
@@ -134,8 +146,6 @@ extension BCOVPageViewController: UIPageViewControllerDataSource {
         } else {
             nextVideoIndex = currentVideoIndex + 1
         }
-
-        print("using video at index \(nextVideoIndex)")
 
         let video = videos[nextVideoIndex]
         videoVC.video = video

--- a/Player/VerticalPlayer/VerticalPlayer/BCOVPageViewController.swift
+++ b/Player/VerticalPlayer/VerticalPlayer/BCOVPageViewController.swift
@@ -74,13 +74,13 @@ final class BCOVPageViewController: UIPageViewController {
             self.videos = videos
 #endif
 
-            if let firstVideo = videos.first,
+            if let firstVideo = self.videos.first,
                let videoVC = newVideoViewController() {
                 videoVC.video = firstVideo
                 setViewControllers([videoVC], direction: .forward, animated: true)
             }
 
-            for video in videos {
+            for video in self.videos {
                 fetchPoster(video: video)
             }
         }

--- a/Player/VerticalPlayer/VerticalPlayer/VideoViewController.swift
+++ b/Player/VerticalPlayer/VerticalPlayer/VideoViewController.swift
@@ -60,15 +60,11 @@ final class VideoViewController: UIViewController {
         return playbackGesture
     }()
 
-    fileprivate lazy var didSetVideo = false
+    fileprivate var didSetVideo = false
 
     fileprivate weak var player: AVPlayer?
 
     weak var video: BCOVVideo?
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-    }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -83,18 +79,19 @@ final class VideoViewController: UIViewController {
             if let posterURLStr = video.properties[BCOVVideo.PropertyKeyPoster] as? String,
                let posterURL = URL(string: posterURLStr) {
                 let urlRequest = URLRequest(url: posterURL)
-                URLSession.shared.dataTask(with: urlRequest) {
+                URLSession.shared.dataTask(with: urlRequest) { [weak self]
                     (data: Data?, response: URLResponse?, error: Error?) in
                     if let error {
                         print(error.localizedDescription)
                         return
                     }
 
-                    guard let data,
+                    guard let self,
+                          let data,
                           let image = UIImage(data: data) else { return }
 
-                    DispatchQueue.main.async { [self] in
-                        posterView.image = image
+                    DispatchQueue.main.async {
+                        self.posterView.image = image
                     }
                 }.resume()
             }
@@ -126,18 +123,19 @@ final class VideoViewController: UIViewController {
 
         let request = URLRequest(url: posterURL)
 
-        URLSession.shared.dataTask(with: request) {
+        URLSession.shared.dataTask(with: request) { [weak self]
             (data: Data?, response: URLResponse?, error: Error?) in
-            guard let data else { return }
+            guard let self,
+                  let data else { return }
             let message = "Check out this video, \"\(videoName)\", it's awesome."
             var items: [Any] = [message]
             if let posterImage = UIImage(data: data) {
                 items = [message, posterImage]
             }
-            DispatchQueue.main.async { [self] in
+            DispatchQueue.main.async {
                 let activityVC = UIActivityViewController(activityItems: items,
                                                           applicationActivities: nil)
-                present(activityVC, animated: true)
+                self.present(activityVC, animated: true)
             }
         }.resume()
     }
@@ -162,15 +160,14 @@ final class VideoViewController: UIViewController {
 // MARK: - BCOVPlaybackControllerDelegate
 
 extension VideoViewController: BCOVPlaybackControllerDelegate {
-    
-    func playbackController(_ controller: BCOVPlaybackController!, 
+
+    func playbackController(_ controller: BCOVPlaybackController!,
                             didAdvanceTo session: BCOVPlaybackSession!) {
         session.playerLayer.videoGravity = .resizeAspectFill
         player = session.player
-        print("ViewController - Advanced to new session.")
     }
-    
-    func playbackController(_ controller: BCOVPlaybackController!, 
+
+    func playbackController(_ controller: BCOVPlaybackController!,
                             playbackSession session: BCOVPlaybackSession!,
                             didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {
 
@@ -185,9 +182,9 @@ extension VideoViewController: BCOVPlaybackControllerDelegate {
         }
 
         if kBCOVPlaybackSessionLifecycleEventFail == lifecycleEvent.eventType,
-           let error = lifecycleEvent.properties["error"] as? NSError {
+           let error = lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError] as? NSError {
             // Report any errors that may have occurred with playback.
-            print("ViewController - Playback error: \(error.localizedDescription)")
+            print("VideoViewController - Playback error: \(error.localizedDescription)")
         }
     }
 }

--- a/Player/Video360/Video360Player/AppDelegate.swift
+++ b/Player/Video360/Video360Player/AppDelegate.swift
@@ -9,7 +9,7 @@ import AVFoundation
 import UIKit
 
 
-@UIApplicationMain
+@main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/Player/Video360/Video360Player/ViewController.swift
+++ b/Player/Video360/Video360Player/ViewController.swift
@@ -87,25 +87,25 @@ final class ViewController: UIViewController {
         return playbackController
     }()
 
-    fileprivate lazy var statusBarHidden = false {
+    fileprivate var statusBarHidden = false {
         didSet {
             setNeedsStatusBarAppearanceUpdate()
         }
     }
 
     override var prefersStatusBarHidden: Bool {
-        return statusBarHidden
+        statusBarHidden
     }
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        return landscapeOnly ? .landscape : .all
+        landscapeOnly ? .landscape : .all
     }
 
     override var shouldAutorotate: Bool {
-        return true
+        true
     }
 
-    fileprivate lazy var landscapeOnly = false
+    fileprivate var landscapeOnly = false
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -196,16 +196,11 @@ final class ViewController: UIViewController {
 extension ViewController: BCOVPlaybackControllerDelegate {
 
     func playbackController(_ controller: BCOVPlaybackController!,
-                            didAdvanceTo session: BCOVPlaybackSession!) {
-        print("ViewController - Advanced to new session.")
-    }
-
-    func playbackController(_ controller: BCOVPlaybackController!,
                             playbackSession session: BCOVPlaybackSession,
                             didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {
 
         if kBCOVPlaybackSessionLifecycleEventFail == lifecycleEvent.eventType,
-           let error = lifecycleEvent.properties["error"] as? NSError {
+           let error = lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError] as? NSError {
             // Report any errors that may have occurred with playback.
             print("ViewController - Playback error: \(error.localizedDescription)")
         }
@@ -229,8 +224,6 @@ extension ViewController: BCOVPUIPlayerViewDelegate {
 
         switch projectionStyle {
             case .normal:
-                print("projectionStyle == BCOVVideo360ProjectionStyleNormal")
-
                 // No landscape restriction
                 landscapeOnly = false
 
@@ -239,8 +232,6 @@ extension ViewController: BCOVPUIPlayerViewDelegate {
                 handleOrientationForStandard()
 
             case .vrGoggles:
-                print("projectionStyle == BCOVVideo360ProjectionStyleVRGoggles")
-
                 // Allow only landscape if wearing goggles
                 landscapeOnly = true
 

--- a/Player/VideoCloudBasicPlayer/VideoCloudBasicPlayer/AppDelegate.swift
+++ b/Player/VideoCloudBasicPlayer/VideoCloudBasicPlayer/AppDelegate.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 
-@UIApplicationMain
+@main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/Player/VideoCloudBasicPlayer/VideoCloudBasicPlayer/NowPlayingHandler.swift
+++ b/Player/VideoCloudBasicPlayer/VideoCloudBasicPlayer/NowPlayingHandler.swift
@@ -15,23 +15,28 @@ final class NowPlayingHandler: NSObject {
 
     fileprivate var nowPlayingInfo: [String: AnyHashable] = [:]
 
+    private var commandTargets: [(MPRemoteCommand, Any)] = []
+
     init(with playbackController: BCOVPlaybackController) {
         super.init()
 
         playbackController.add(self)
 
         let center = MPRemoteCommandCenter.shared()
-        center.pauseCommand.addTarget { _ in
+
+        let pauseTarget = center.pauseCommand.addTarget { _ in
             playbackController.pause()
             return .success
         }
+        commandTargets.append((center.pauseCommand, pauseTarget))
 
-        center.playCommand.addTarget { _ in
+        let playTarget = center.playCommand.addTarget { _ in
             playbackController.play()
             return .success
         }
+        commandTargets.append((center.playCommand, playTarget))
 
-        center.changePlaybackPositionCommand.addTarget { command in
+        let changePlaybackPositionTarget = center.changePlaybackPositionCommand.addTarget { command in
             guard let playbackPositionCommandEvent = command as? MPChangePlaybackPositionCommandEvent else {
                 return .commandFailed
             }
@@ -41,8 +46,9 @@ final class NowPlayingHandler: NSObject {
 
             return .success
         }
+        commandTargets.append((center.changePlaybackPositionCommand, changePlaybackPositionTarget))
 
-        center.togglePlayPauseCommand.addTarget { [weak self] _ in
+        let togglePlayPauseTarget = center.togglePlayPauseCommand.addTarget { [weak self] _ in
             guard let self, let session, let player = session.player else { return .commandFailed }
 
             if player.timeControlStatus == .paused {
@@ -52,6 +58,13 @@ final class NowPlayingHandler: NSObject {
             }
 
             return .success
+        }
+        commandTargets.append((center.togglePlayPauseCommand, togglePlayPauseTarget))
+    }
+
+    deinit {
+        for (cmd, token) in commandTargets {
+            cmd.removeTarget(token)
         }
     }
 
@@ -138,19 +151,27 @@ extension NowPlayingHandler: BCOVPlaybackSessionConsumer {
 
         if let posterURL = video.properties[BCOVVideo.PropertyKeyPoster] as? String,
            let url = URL(string: posterURL) {
-            DispatchQueue.global(qos: .background).async { [self] in
-                do {
-                    let imageData = try Data(contentsOf: url)
-                    if let image = UIImage(data: imageData) {
-                        nowPlayingInfo[MPMediaItemPropertyArtwork] = MPMediaItemArtwork(boundsSize: image.size) { _ in image }
-
-                        let infoCenter = MPNowPlayingInfoCenter.default()
-                        infoCenter.nowPlayingInfo = nowPlayingInfo
-                    }
-                } catch {
+            URLSession.shared.dataTask(with: url) { [weak self] (data: Data?,
+                                                                 response: URLResponse?,
+                                                                 error: Error?) in
+                if let error {
                     print("Error getting thumbnail image data: \(error.localizedDescription)")
+                    return
                 }
-            }
+
+                DispatchQueue.main.async {
+                    guard let self,
+                          let data,
+                          let image = UIImage(data: data) else {
+                        return
+                    }
+
+                    self.nowPlayingInfo[MPMediaItemPropertyArtwork] = MPMediaItemArtwork(boundsSize: image.size) { _ in image }
+
+                    let infoCenter = MPNowPlayingInfoCenter.default()
+                    infoCenter.nowPlayingInfo = self.nowPlayingInfo
+                }
+            }.resume()
         }
     }
 

--- a/Player/VideoCloudBasicPlayer/VideoCloudBasicPlayer/NowPlayingHandler.swift
+++ b/Player/VideoCloudBasicPlayer/VideoCloudBasicPlayer/NowPlayingHandler.swift
@@ -13,7 +13,7 @@ final class NowPlayingHandler: NSObject {
 
     fileprivate weak var session: BCOVPlaybackSession?
 
-    fileprivate lazy var nowPlayingInfo: [String: AnyHashable] = [:]
+    fileprivate var nowPlayingInfo: [String: AnyHashable] = [:]
 
     init(with playbackController: BCOVPlaybackController) {
         super.init()
@@ -42,8 +42,8 @@ final class NowPlayingHandler: NSObject {
             return .success
         }
 
-        center.togglePlayPauseCommand.addTarget { [self] _ in
-            guard let session, let player = session.player else { return .commandFailed }
+        center.togglePlayPauseCommand.addTarget { [weak self] _ in
+            guard let self, let session, let player = session.player else { return .commandFailed }
 
             if player.timeControlStatus == .paused {
                 playbackController.play()
@@ -56,7 +56,7 @@ final class NowPlayingHandler: NSObject {
     }
 
     func updateNowPlayingInfoForAudioOnly() {
-        guard let video = session?.video , let customFields = video.properties["custom_fields"] as? [String: Any] else {
+        guard let video = session?.video, let customFields = video.properties["custom_fields"] as? [String: Any] else {
             return
         }
 
@@ -95,7 +95,6 @@ extension NowPlayingHandler {
             let infoCenter = MPNowPlayingInfoCenter.default()
             nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = rate
             infoCenter.nowPlayingInfo = nowPlayingInfo
-            self.nowPlayingInfo = nowPlayingInfo
         }
     }
 }
@@ -121,7 +120,7 @@ extension NowPlayingHandler: BCOVPlaybackSessionConsumer {
                                    context: nil)
         }
 
-        nowPlayingInfo = [String: AnyHashable]()
+        nowPlayingInfo = [:]
 
         guard let video = session.video, let videoName = video.localizedName(forLocale: nil),
               let durationNum = video.properties[BCOVVideo.PropertyKeyDuration] as? NSNumber else {
@@ -143,10 +142,7 @@ extension NowPlayingHandler: BCOVPlaybackSessionConsumer {
                 do {
                     let imageData = try Data(contentsOf: url)
                     if let image = UIImage(data: imageData) {
-                        nowPlayingInfo[MPMediaItemPropertyArtwork] = MPMediaItemArtwork(boundsSize: image.size) {
-                            _ -> UIImage in
-                            return image
-                        }
+                        nowPlayingInfo[MPMediaItemPropertyArtwork] = MPMediaItemArtwork(boundsSize: image.size) { _ in image }
 
                         let infoCenter = MPNowPlayingInfoCenter.default()
                         infoCenter.nowPlayingInfo = nowPlayingInfo

--- a/Player/VideoCloudBasicPlayer/VideoCloudBasicPlayer/ViewController.swift
+++ b/Player/VideoCloudBasicPlayer/VideoCloudBasicPlayer/ViewController.swift
@@ -5,6 +5,19 @@
 //  Copyright © 2026 Brightcove, Inc. All rights reserved.
 //
 
+/*
+ * This sample app shows the basic setup for playing a single video from
+ * Video Cloud: `BCOVPlaybackService.findVideo` retrieves the video and it is
+ * played in a `BCOVPUIPlayerView` driven by a playback controller.
+ *
+ * It also demonstrates several features layered on top of basic playback:
+ * AirPlay (external playback plus toggling the route detector), background
+ * audio via the `AVAudioSession` category, Picture-in-Picture through the
+ * player view delegate, and lock-screen Now Playing info and remote commands
+ * via `MPRemoteCommandCenter` / `MPNowPlayingInfoCenter` (see NowPlayingHandler),
+ * including artwork and audio-only assets built from Video Cloud custom fields.
+ */
+
 import AVKit
 import UIKit
 import BrightcovePlayerSDK
@@ -78,13 +91,13 @@ final class ViewController: UIViewController {
         return playbackController
     }()
 
-    fileprivate lazy var statusBarHidden = false {
+    fileprivate var statusBarHidden = false {
         didSet {
             setNeedsStatusBarAppearanceUpdate()
         }
     }
 
-    fileprivate lazy var nowPlayingHandler: NowPlayingHandler? = nil
+    fileprivate var nowPlayingHandler: NowPlayingHandler?
 
     fileprivate weak var currentPlayer: AVPlayer?
 
@@ -154,18 +167,18 @@ final class ViewController: UIViewController {
                 if currentPlayer.isMuted {
                     try AVAudioSession.sharedInstance().setCategory(.playback, options: .mixWithOthers)
                 } else {
-                    try AVAudioSession.sharedInstance().setCategory(.playback, options: AVAudioSession.CategoryOptions(rawValue: 0))
+                    try AVAudioSession.sharedInstance().setCategory(.playback, options: [])
                 }
             } else {
-                try AVAudioSession.sharedInstance().setCategory(.playback, options: AVAudioSession.CategoryOptions(rawValue: 0))
+                try AVAudioSession.sharedInstance().setCategory(.playback, options: [])
             }
         } catch {
-            print("AppDelegate - Error setting AVAudioSession category. Because of this, there may be no sound. \(error)")
+            print("ViewController - Error setting AVAudioSession category. Because of this, there may be no sound. \(error)")
         }
     }
 
     @IBAction
-    fileprivate func  muteButtonPressed(_ button: UIButton) {
+    fileprivate func muteButtonPressed(_ button: UIButton) {
         guard let currentPlayer else { return }
 
         if currentPlayer.isMuted {
@@ -187,8 +200,6 @@ extension ViewController: BCOVPlaybackControllerDelegate {
 
     func playbackController(_ controller: BCOVPlaybackController!,
                             didAdvanceTo session: BCOVPlaybackSession!) {
-        print("ViewController - Advanced to new session.")
-
         currentPlayer = session.player
 
         if let routeDetector = playerView?.controlsView?.routeDetector {
@@ -202,7 +213,7 @@ extension ViewController: BCOVPlaybackControllerDelegate {
                             playbackSession session: BCOVPlaybackSession!,
                             didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {
         if kBCOVPlaybackSessionLifecycleEventFail == lifecycleEvent.eventType,
-           let error = lifecycleEvent.properties["error"] as? NSError {
+           let error = lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError] as? NSError {
             // Report any errors that may have occurred with playback.
             print("ViewController - Playback error: \(error.localizedDescription)")
         }
@@ -213,12 +224,6 @@ extension ViewController: BCOVPlaybackControllerDelegate {
             // https://developer.apple.com/documentation/avfoundation/avroutedetector/2915762-routedetectionenabled
             routeDetector.isRouteDetectionEnabled = false
         }
-    }
-
-    func playbackController(_ controller: BCOVPlaybackController!,
-                            playbackSession session: BCOVPlaybackSession!,
-                            didProgressTo progress: TimeInterval) {
-        print("Progress: \(progress) seconds")
     }
 
     func playbackController(_ controller: BCOVPlaybackController!,
@@ -242,22 +247,6 @@ extension ViewController: BCOVPUIPlayerViewDelegate {
     func playerView(_ playerView: BCOVPUIPlayerView!,
                     willTransitionTo screenMode: BCOVPUIScreenMode) {
         statusBarHidden = screenMode == .full
-    }
-
-    func pictureInPictureControllerDidStartPicture(inPicture pictureInPictureController: AVPictureInPictureController) {
-        print("pictureInPictureControllerDidStartPicture")
-    }
-
-    func pictureInPictureControllerDidStopPicture(inPicture pictureInPictureController: AVPictureInPictureController) {
-        print("pictureInPictureControllerDidStopPicture")
-    }
-
-    func pictureInPictureControllerWillStartPicture(inPicture pictureInPictureController: AVPictureInPictureController) {
-        print("pictureInPictureControllerWillStartPicture")
-    }
-
-    func pictureInPictureControllerWillStopPicture(inPicture pictureInPictureController: AVPictureInPictureController) {
-        print("pictureInPictureControllerWillStopPicture")
     }
 
     func picture(_ pictureInPictureController: AVPictureInPictureController!,

--- a/Player/VideoPreloading/VideoPreloading/AppDelegate.swift
+++ b/Player/VideoPreloading/VideoPreloading/AppDelegate.swift
@@ -9,7 +9,7 @@ import AVFoundation
 import UIKit
 
 
-@UIApplicationMain
+@main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/Player/VideoPreloading/VideoPreloading/VideoPreloadManager.swift
+++ b/Player/VideoPreloading/VideoPreloading/VideoPreloadManager.swift
@@ -63,8 +63,8 @@ final class VideoPreloadManager: NSObject {
         return playbackController
     }()
 
-    fileprivate lazy var didBeginPreloadingNextSession: Bool = false
-    fileprivate lazy var currentVideoIndex: Int = 0
+    fileprivate var didBeginPreloadingNextSession = false
+    fileprivate var currentVideoIndex = 0
 
     fileprivate let autoPlayEnabled: Bool
     fileprivate weak var playerView: BCOVPUIPlayerView?
@@ -84,7 +84,7 @@ final class VideoPreloadManager: NSObject {
          and shouldAutoPlay: Bool,
          and delegate: BCOVPlaybackControllerDelegate?) {
 
-        self.delegate = delegate;
+        self.delegate = delegate
         self.autoPlayEnabled = shouldAutoPlay
 
         // Keep a weak reference to the BCOVPUIPlayerView object so we can
@@ -94,7 +94,7 @@ final class VideoPreloadManager: NSObject {
         super.init()
     }
 
-    func preloadNextVideoIfNeccessary(_ currentSession: BCOVPlaybackSession) {
+    func preloadNextVideoIfNecessary(_ currentSession: BCOVPlaybackSession) {
         if shouldPreloadNextSession(currentSession) {
             preloadNextSession()
         }

--- a/Player/VideoPreloading/VideoPreloading/ViewController.swift
+++ b/Player/VideoPreloading/VideoPreloading/ViewController.swift
@@ -5,6 +5,21 @@
 //  Copyright © 2026 Brightcove, Inc. All rights reserved.
 //
 
+/*
+ * This sample app shows how to seamlessly advance between videos by preloading
+ * the next video while the current one is still playing ("double buffering").
+ *
+ * Two `BCOVPlaybackController`s share a single `BCOVPUIPlayerView`. While the
+ * current controller plays, `VideoPreloadManager` loads the upcoming video into
+ * the other controller so it is ready to display the moment playback ends.
+ * Preloading starts once the current video passes the 75% progress threshold
+ * (`kPreloadNextSessionThreshold`), reported through `-didProgressTo`. Because
+ * auto-advance is disabled, the manager swaps the player view's controller on
+ * the playback-end lifecycle event.
+ *
+ * The playlist is fetched by reference id with `-findPlaylistWithConfiguration:`.
+ */
+
 import UIKit
 import BrightcovePlayerSDK
 
@@ -46,14 +61,14 @@ final class ViewController: UIViewController {
         return playerView
     }()
 
-    fileprivate lazy var statusBarHidden = false {
+    fileprivate var statusBarHidden = false {
         didSet {
             setNeedsStatusBarAppearanceUpdate()
         }
     }
 
     override var prefersStatusBarHidden: Bool {
-        return statusBarHidden
+        statusBarHidden
     }
 
     fileprivate lazy var videoPreloadManager: VideoPreloadManager? = {
@@ -71,11 +86,12 @@ final class ViewController: UIViewController {
         let configuration = [BCOVPlaybackService.ConfigurationKeyAssetReferenceID: kPlaylistRefId]
         playbackService.findPlaylist(withConfiguration: configuration,
                                      queryParameters: nil) {
-            [self] (playlist: BCOVPlaylist?,
-                    json: Any?,
-                    error: Error?) in
+            [weak self] (playlist: BCOVPlaylist?,
+                         json: Any?,
+                         error: Error?) in
 
-            guard let videoPreloadManager,
+            guard let self,
+                  let videoPreloadManager,
                   let playlist else {
                 if let error {
                     print("ViewController - Error retrieving video playlist: \(error.localizedDescription)")
@@ -101,11 +117,6 @@ final class ViewController: UIViewController {
 extension ViewController: BCOVPlaybackControllerDelegate {
 
     func playbackController(_ controller: BCOVPlaybackController!,
-                            didAdvanceTo session: BCOVPlaybackSession!) {
-        print("ViewController - Advanced to new session.")
-    }
-
-    func playbackController(_ controller: BCOVPlaybackController!,
                             playbackSession session: BCOVPlaybackSession,
                             didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {
         if kBCOVPlaybackSessionLifecycleEventEnd == lifecycleEvent.eventType,
@@ -115,12 +126,10 @@ extension ViewController: BCOVPlaybackControllerDelegate {
     }
 
     func playbackController(_ controller: BCOVPlaybackController!,
-                            playbackSession session: BCOVPlaybackSession!,
+                            playbackSession session: BCOVPlaybackSession,
                             didProgressTo progress: TimeInterval) {
-        print("Progress: \(progress) seconds")
-
         if let videoPreloadManager {
-            videoPreloadManager.preloadNextVideoIfNeccessary(session)
+            videoPreloadManager.preloadNextVideoIfNecessary(session)
         }
     }
 }

--- a/PlayerUI/CustomControls/CustomControls/AppDelegate.swift
+++ b/PlayerUI/CustomControls/CustomControls/AppDelegate.swift
@@ -9,7 +9,7 @@ import AVFoundation
 import UIKit
 
 
-@UIApplicationMain
+@main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/PlayerUI/CustomControls/CustomControls/ClosedCaptionMenuController.swift
+++ b/PlayerUI/CustomControls/CustomControls/ClosedCaptionMenuController.swift
@@ -33,7 +33,7 @@ final class ClosedCaptionMenuController: UITableViewController {
                         mediaOptionTypes.append(AVMediaCharacteristic.audible)
                     }
 
-                    if legibleMediaOptions.count > 0 {
+                    if !legibleMediaOptions.isEmpty {
                         mediaOptionTypes.append(AVMediaCharacteristic.legible)
                     }
 
@@ -44,7 +44,7 @@ final class ClosedCaptionMenuController: UITableViewController {
 
                         // Enable closed caption button if there are closed captions OR more than 1 soundtrack.
                         // Do this on main thread because closedCaptionEnabled changes the UI.
-                        let closedCaptionEnabled = legibleMediaOptions.count > 0 || audibleMediaOptions.count > 1
+                        let closedCaptionEnabled = !legibleMediaOptions.isEmpty || audibleMediaOptions.count > 1
                         controlsView.closedCaptionEnabled = closedCaptionEnabled
                     }
                 }
@@ -54,7 +54,7 @@ final class ClosedCaptionMenuController: UITableViewController {
 
     // sort the options in order of preferred language.
     fileprivate lazy var sortDescriptor = {
-        [self] (obj1: Any, obj2: Any) -> ComparisonResult in
+        (obj1: Any, obj2: Any) -> ComparisonResult in
 
         guard let option1 = obj1 as? AVMediaSelectionOption,
               let option2 = obj2 as? AVMediaSelectionOption else {
@@ -72,7 +72,7 @@ final class ClosedCaptionMenuController: UITableViewController {
         }
 
         // set up the sort order. boil the language IDs down to their language codes (en, instead of en_US).
-        var preferredLanguageCodes: [String] = .init()
+        var preferredLanguageCodes: [String] = []
         for aLanguage in NSLocale.preferredLanguages {
             guard let theLanguageCode = NSLocale.components(fromLocaleIdentifier: aLanguage)[NSLocale.Key.languageCode.rawValue] else {
                 continue
@@ -125,11 +125,9 @@ final class ClosedCaptionMenuController: UITableViewController {
 
         // construct a list of subtitles and closed captions with valid locales.
         var validLegibleOptions = [AVMediaSelectionOption]()
-        for option in legibleGroup.options {
-            if option.mediaType == .subtitle ||
-                option.mediaType == .closedCaption {
-                validLegibleOptions.append(option)
-            }
+        for option in legibleGroup.options where option.mediaType == .subtitle ||
+            option.mediaType == .closedCaption {
+            validLegibleOptions.append(option)
         }
 
         // return the list of playable, unforced subtitles & closed captions. refer
@@ -245,7 +243,7 @@ extension ClosedCaptionMenuController {
         return headerView
     }
 
-    fileprivate func tableViewSectionIsAudibleSection(_ section:  Int) -> Bool {
+    fileprivate func tableViewSectionIsAudibleSection(_ section: Int) -> Bool {
         guard let mediaOptionsTableViewSectionList else {
             return false
         }
@@ -253,7 +251,7 @@ extension ClosedCaptionMenuController {
         return mediaOptionsTableViewSectionList[section] == AVMediaCharacteristic.audible
     }
 
-    fileprivate func tableViewSectionIsLegibleSection(_ section:  Int) -> Bool {
+    fileprivate func tableViewSectionIsLegibleSection(_ section: Int) -> Bool {
         guard let mediaOptionsTableViewSectionList else {
             return false
         }

--- a/PlayerUI/CustomControls/CustomControls/ControlsViewController.swift
+++ b/PlayerUI/CustomControls/CustomControls/ControlsViewController.swift
@@ -46,13 +46,6 @@ final class ControlsViewController: UIViewController {
         return ccMenuController
     }()
 
-    fileprivate lazy var numberFormatter: NumberFormatter = {
-        let formatter = NumberFormatter()
-        formatter.paddingCharacter = "0"
-        formatter.minimumIntegerDigits = 2
-        return formatter
-    }()
-
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -127,18 +120,11 @@ final class ControlsViewController: UIViewController {
             return "00:00"
         }
 
-        let hours = floor(timeInterval / 60.0 / 60.0)
-        let minutes = (timeInterval / 60).truncatingRemainder(dividingBy: 60)
-        let seconds = timeInterval.truncatingRemainder(dividingBy: 60)
-
-        guard let formattedMinutes = numberFormatter.string(from: NSNumber(value: minutes)),
-              let formattedSeconds = numberFormatter.string(from: NSNumber(value: seconds)) else {
-            return nil
-        }
-
-        return (hours > 0 ?
-                "\(hours):\(formattedMinutes):\(formattedSeconds)" :
-                    "\(formattedMinutes):\(formattedSeconds)")
+        let total = Int(timeInterval)
+        let hours = total / 3600
+        let minutes = (total / 60) % 60
+        let seconds = total % 60
+        return hours > 0 ? String(format: "%d:%02d:%02d", hours, minutes, seconds) : String(format: "%02d:%02d", minutes, seconds)
     }
 
     @IBAction

--- a/PlayerUI/CustomControls/CustomControls/ControlsViewController.swift
+++ b/PlayerUI/CustomControls/CustomControls/ControlsViewController.swift
@@ -12,7 +12,7 @@ import BrightcovePlayerSDK
 fileprivate struct ControlConstants {
     static let VisibleDuration: TimeInterval = 5.0
     static let AnimateInDuration: TimeInterval = 0.1
-    static let AnimateOutDuraton: TimeInterval = 0.2
+    static let AnimateOutDuration: TimeInterval = 0.2
 }
 
 
@@ -31,14 +31,14 @@ final class ControlsViewController: UIViewController {
     weak var currentPlayer: AVPlayer?
     weak var playbackController: BCOVPlaybackController?
 
-    var closedCaptionEnabled: Bool = false {
+    var closedCaptionEnabled = false {
         didSet {
             closedCaptionButton.isEnabled = closedCaptionEnabled
         }
     }
 
     fileprivate var controlTimer: Timer?
-    fileprivate var playingOnSeek: Bool = false
+    fileprivate var playingOnSeek = false
 
     fileprivate lazy var ccMenuController: ClosedCaptionMenuController = {
         let ccMenuController = ClosedCaptionMenuController(style: .grouped)
@@ -75,7 +75,7 @@ final class ControlsViewController: UIViewController {
         if playPauseButton.isSelected {
             if controlsContainer.alpha == 0.0 {
                 fadeControlsIn()
-            } else if (controlsContainer.alpha == 1.0) {
+            } else if controlsContainer.alpha == 1.0 {
                 fadeControlsOut()
             }
         }
@@ -84,7 +84,7 @@ final class ControlsViewController: UIViewController {
     fileprivate func fadeControlsIn() {
         UIView.animate(withDuration: ControlConstants.AnimateInDuration) { [self] in
             showControls()
-        } completion:{ [self] (finished: Bool) in
+        } completion: { [self] (finished: Bool) in
             if finished {
                 reestablishTimer()
             }
@@ -93,7 +93,7 @@ final class ControlsViewController: UIViewController {
 
     @objc
     fileprivate func fadeControlsOut() {
-        UIView.animate(withDuration: ControlConstants.AnimateOutDuraton) { [self] in
+        UIView.animate(withDuration: ControlConstants.AnimateOutDuration) { [self] in
             hideControls()
         }
     }
@@ -127,7 +127,7 @@ final class ControlsViewController: UIViewController {
             return "00:00"
         }
 
-        let hours  = floor(timeInterval / 60.0 / 60.0)
+        let hours = floor(timeInterval / 60.0 / 60.0)
         let minutes = (timeInterval / 60).truncatingRemainder(dividingBy: 60)
         let seconds = timeInterval.truncatingRemainder(dividingBy: 60)
 
@@ -154,8 +154,8 @@ final class ControlsViewController: UIViewController {
 
     @IBAction
     fileprivate func handlePlayheadSliderTouchEnd(_ slider: UISlider) {
-        if let currentTime = currentPlayer?.currentItem {
-            let newCurrentTime = Float64(slider.value) * CMTimeGetSeconds(currentTime.duration)
+        if let currentItem = currentPlayer?.currentItem {
+            let newCurrentTime = Float64(slider.value) * CMTimeGetSeconds(currentItem.duration)
             let seekToTime = CMTimeMakeWithSeconds(newCurrentTime, preferredTimescale: 600)
 
             playbackController?.seek(to: seekToTime) { [self] (finished: Bool) in
@@ -173,8 +173,8 @@ final class ControlsViewController: UIViewController {
 
     @IBAction
     fileprivate func handlePlayheadSliderValueChanged(_ slider: UISlider) {
-        if let currentTime = currentPlayer?.currentItem {
-            let currentTime = Float64(slider.value) * CMTimeGetSeconds(currentTime.duration)
+        if let currentItem = currentPlayer?.currentItem {
+            let currentTime = Float64(slider.value) * CMTimeGetSeconds(currentItem.duration)
             playheadLabel.text = formatTime(timeInterval: currentTime)
         }
     }
@@ -234,7 +234,7 @@ extension ControlsViewController: BCOVPlaybackSessionConsumer {
 
         switch lifecycleEvent.eventType {
             case kBCOVPlaybackSessionLifecycleEventPlay:
-                playPauseButton?.isSelected = true
+                playPauseButton.isSelected = true
                 reestablishTimer()
             case kBCOVPlaybackSessionLifecycleEventPause:
                 playPauseButton.isSelected = false

--- a/PlayerUI/CustomControls/CustomControls/ViewController.swift
+++ b/PlayerUI/CustomControls/CustomControls/ViewController.swift
@@ -75,12 +75,12 @@ final class ViewController: UIViewController {
     }()
 
     fileprivate lazy var fullscreenVideoViewConstraints: [NSLayoutConstraint] = {
-        var insets = view.safeAreaInsets
+        let insets = view.safeAreaInsets
         return [
-            videoView.topAnchor.constraint(equalTo: fullscreenViewController.view.topAnchor, constant:insets.top),
+            videoView.topAnchor.constraint(equalTo: fullscreenViewController.view.topAnchor, constant: insets.top),
             videoView.rightAnchor.constraint(equalTo: fullscreenViewController.view.rightAnchor),
             videoView.leftAnchor.constraint(equalTo: fullscreenViewController.view.leftAnchor),
-            videoView.bottomAnchor.constraint(equalTo: fullscreenViewController.view.bottomAnchor, constant:-insets.bottom)
+            videoView.bottomAnchor.constraint(equalTo: fullscreenViewController.view.bottomAnchor, constant: -insets.bottom)
         ]
     }()
 
@@ -175,16 +175,11 @@ final class ViewController: UIViewController {
 extension ViewController: BCOVPlaybackControllerDelegate {
 
     func playbackController(_ controller: BCOVPlaybackController!,
-                            didAdvanceTo session: BCOVPlaybackSession!) {
-        print("ViewController - Advanced to new session.")
-    }
-
-    func playbackController(_ controller: BCOVPlaybackController!,
                             playbackSession session: BCOVPlaybackSession,
                             didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {
 
         if kBCOVPlaybackSessionLifecycleEventFail == lifecycleEvent.eventType,
-           let error = lifecycleEvent.properties["error"] as? NSError {
+           let error = lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError] as? NSError {
             // Report any errors that may have occurred with playback.
             print("ViewController - Playback error: \(error.localizedDescription)")
         }

--- a/PlayerUI/PlayerUICustomization/PlayerUICustomization/AppDelegate.swift
+++ b/PlayerUI/PlayerUICustomization/PlayerUICustomization/AppDelegate.swift
@@ -9,7 +9,7 @@ import AVFoundation
 import UIKit
 
 
-@UIApplicationMain
+@main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/PlayerUI/PlayerUICustomization/PlayerUICustomization/CustomLayouts.swift
+++ b/PlayerUI/PlayerUICustomization/PlayerUICustomization/CustomLayouts.swift
@@ -63,7 +63,7 @@ final class CustomLayouts: NSObject {
 
         let compactLayoutLines = [compactLayoutLine1, compactLayoutLine2]
 
-        // Put the two layout lines into a single control layout object.
+        // Put the layout lines into a single control layout object.
         let layout = BCOVPUIControlLayout(standardControls: standardLayoutLines,
                                           compactControls: compactLayoutLines)
 
@@ -207,7 +207,7 @@ final class CustomLayouts: NSObject {
 
         let compactLayoutLines = [compactLayoutLine1]
 
-        // Put the two layout lines into a single control layout object.
+        // Put the layout lines into a single control layout object.
         let layout = BCOVPUIControlLayout(standardControls: standardLayoutLines,
                                           compactControls: compactLayoutLines)
 

--- a/PlayerUI/PlayerUICustomization/PlayerUICustomization/ViewController.swift
+++ b/PlayerUI/PlayerUICustomization/PlayerUICustomization/ViewController.swift
@@ -238,7 +238,8 @@ final class ViewController: UIViewController {
 
         guard let playerView,
               let controlsView = playerView.controlsView,
-              let hideableLayoutView = controlsView.layout.allLayoutItems.first(where: { ($0 as? BCOVPUILayoutView)?.tag == BCOVPUIViewTag.buttonPlayback.rawValue }) as? BCOVPUILayoutView else { return }
+              let layout = controlsView.layout,
+              let hideableLayoutView = layout.allLayoutItems.first(where: { ($0 as? BCOVPUILayoutView)?.tag == BCOVPUIViewTag.buttonPlayback.rawValue }) as? BCOVPUILayoutView else { return }
 
         // When the device is shaken, toggle the removal of the saved layout view.
         hideableLayoutView.isRemoved = !hideableLayoutView.isRemoved

--- a/PlayerUI/PlayerUICustomization/PlayerUICustomization/ViewController.swift
+++ b/PlayerUI/PlayerUICustomization/PlayerUICustomization/ViewController.swift
@@ -9,7 +9,7 @@
 // The PlayerUI code is now integrated in the BrightcovePlayerSDK module, so you
 // can begin using it without importing any other modules besides the BrightcovePlayerSDK.
 //
-// There are five sample layouts. When you run the app, you can dynamically
+// There are six sample layouts. When you run the app, you can dynamically
 // switch between all the layouts to see them in action.
 //
 // 1 - Built-in VOD Controls
@@ -93,7 +93,7 @@ final class ViewController: UIViewController {
         func setup(forControlsView controlsView: BCOVPUIBasicControlView,
                    compactLayoutMaximumWidth: CGFloat) {
 
-            lazy var controlLayout: BCOVPUIControlLayout? = nil
+            var controlLayout: BCOVPUIControlLayout? = nil
 
             switch self {
                 case .Basic:
@@ -162,12 +162,12 @@ final class ViewController: UIViewController {
         playerView.frame = videoContainerView.bounds
         videoContainerView.addSubview(playerView)
 
-        if playerView.controlsView != nil {
-            playerView.controlsView.durationLabel.accessibilityLabelPrefix = "Total Time"
-            playerView.controlsView.currentTimeLabel.accessibilityLabelPrefix = "As of now"
-            playerView.controlsView.progressSlider.accessibilityLabel = "Timeline"
+        if let controlsView = playerView.controlsView {
+            controlsView.durationLabel.accessibilityLabelPrefix = "Total Time"
+            controlsView.currentTimeLabel.accessibilityLabelPrefix = "As of now"
+            controlsView.progressSlider.accessibilityLabel = "Timeline"
 
-            playerView.controlsView.setButtonsAccessibilityDelegate(self)
+            controlsView.setButtonsAccessibilityDelegate(self)
         }
 
         return playerView
@@ -199,7 +199,7 @@ final class ViewController: UIViewController {
     }()
 
     fileprivate lazy var compactLayoutMaximumWidth: CGFloat = {
-        return (view.frame.width + view.frame.height) / 2
+        (view.frame.width + view.frame.height) / 2
     }()
 
     // Which layout are we displaying?
@@ -214,7 +214,7 @@ final class ViewController: UIViewController {
         }
     }
 
-    fileprivate lazy var statusBarHidden = false {
+    fileprivate var statusBarHidden = false {
         didSet {
             setNeedsStatusBarAppearanceUpdate()
         }
@@ -241,11 +241,9 @@ final class ViewController: UIViewController {
               let hideableLayoutView = controlsView.layout.allLayoutItems.first(where: { ($0 as? BCOVPUILayoutView)?.tag == BCOVPUIViewTag.buttonPlayback.rawValue }) as? BCOVPUILayoutView else { return }
 
         // When the device is shaken, toggle the removal of the saved layout view.
-        print("motionBegan - hiding/showing layout view")
-
         hideableLayoutView.isRemoved = !hideableLayoutView.isRemoved
 
-        playerView.controlsView.setNeedsLayout()
+        controlsView.setNeedsLayout()
     }
 
     @objc
@@ -338,16 +336,11 @@ final class ViewController: UIViewController {
 extension ViewController: BCOVPlaybackControllerDelegate {
 
     func playbackController(_ controller: BCOVPlaybackController!,
-                            didAdvanceTo session: BCOVPlaybackSession!) {
-        print("ViewController - Advanced to new session.")
-    }
-
-    func playbackController(_ controller: BCOVPlaybackController!,
                             playbackSession session: BCOVPlaybackSession,
                             didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {
 
         if kBCOVPlaybackSessionLifecycleEventFail == lifecycleEvent.eventType,
-           let error = lifecycleEvent.properties["error"] as? NSError {
+           let error = lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError] as? NSError {
             // Report any errors that may have occurred with playback.
             print("ViewController - Playback error: \(error.localizedDescription)")
         }

--- a/PlayerUI/ViewStrategy/ViewStrategy/AppDelegate.swift
+++ b/PlayerUI/ViewStrategy/ViewStrategy/AppDelegate.swift
@@ -9,7 +9,7 @@ import AVFoundation
 import UIKit
 
 
-@UIApplicationMain
+@main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/PlayerUI/ViewStrategy/ViewStrategy/ViewController.swift
+++ b/PlayerUI/ViewStrategy/ViewStrategy/ViewController.swift
@@ -5,6 +5,19 @@
 //  Copyright © 2026 Brightcove, Inc. All rights reserved.
 //
 
+/*
+ * This sample app shows how to build a `BCOVPlaybackController` with a custom
+ * view strategy.
+ *
+ * A view strategy is a closure the SDK calls to build the controller's `view`.
+ * It is passed to
+ * `BCOVPlayerSDKManager.createPlaybackController(withSessionProvider:viewStrategy:)`.
+ * Here the strategy composes the SDK's video view and a custom
+ * `ViewStrategyCustomControls` view into a single container, and registers the
+ * controls as a session consumer with `-add:` so they receive playback progress
+ * and lifecycle updates.
+ */
+
 import UIKit
 import BrightcovePlayerSDK
 
@@ -134,16 +147,11 @@ final class ViewController: UIViewController {
 extension ViewController: BCOVPlaybackControllerDelegate {
 
     func playbackController(_ controller: BCOVPlaybackController!,
-                            didAdvanceTo session: BCOVPlaybackSession!) {
-        print("ViewController - Advanced to new session.")
-    }
-
-    func playbackController(_ controller: BCOVPlaybackController!,
                             playbackSession session: BCOVPlaybackSession,
                             didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {
 
         if kBCOVPlaybackSessionLifecycleEventFail == lifecycleEvent.eventType,
-           let error = lifecycleEvent.properties["error"] as? NSError {
+           let error = lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError] as? NSError {
             // Report any errors that may have occurred with playback.
             print("ViewController - Playback error: \(error.localizedDescription)")
         }

--- a/PlayerUI/ViewStrategy/ViewStrategy/ViewStrategyCustomControls.swift
+++ b/PlayerUI/ViewStrategy/ViewStrategy/ViewStrategyCustomControls.swift
@@ -70,14 +70,14 @@ final class ViewStrategyCustomControls: UIView {
         addSubview(playPauseButton)
         addSubview(progressView)
 
-        NSLayoutConstraint.activate(constraints)
+        NSLayoutConstraint.activate(makeConstraints())
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override var constraints: [NSLayoutConstraint] {
+    private func makeConstraints() -> [NSLayoutConstraint] {
         let option: NSLayoutConstraint.FormatOptions = .directionLeadingToTrailing
         let views = [
             "superview": self,

--- a/PlayerUI/ViewStrategy/ViewStrategy/ViewStrategyCustomControls.swift
+++ b/PlayerUI/ViewStrategy/ViewStrategy/ViewStrategyCustomControls.swift
@@ -177,7 +177,7 @@ extension ViewStrategyCustomControls: BCOVPlaybackSessionConsumer {
         }
     }
 
-    func playbackSession(_ session: BCOVPlaybackSession!,
+    func playbackSession(_ session: BCOVPlaybackSession,
                          didProgressTo progress: TimeInterval) {
         guard let duration = session.player?.currentItem?.duration,
               duration.isValid,

--- a/Pulse/BasicPulsePlayer-iOS/BasicPulsePlayer/AppDelegate.swift
+++ b/Pulse/BasicPulsePlayer-iOS/BasicPulsePlayer/AppDelegate.swift
@@ -9,7 +9,7 @@ import AVFoundation
 import UIKit
 
 
-@UIApplicationMain
+@main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/Pulse/BasicPulsePlayer-iOS/BasicPulsePlayer/BCOVPulseVideoItem.swift
+++ b/Pulse/BasicPulsePlayer-iOS/BasicPulsePlayer/BCOVPulseVideoItem.swift
@@ -12,17 +12,17 @@ final class BCOVPulseVideoItem: NSObject {
 
     fileprivate(set) var title: String?
     fileprivate(set) var category: String?
-    fileprivate(set) var tags: Array<String>?
-    fileprivate(set) var midrollPositions: Array<NSNumber>?
-    fileprivate(set) var extendSession: Bool? = false
+    fileprivate(set) var tags: [String]?
+    fileprivate(set) var midrollPositions: [NSNumber]?
+    fileprivate(set) var extendSession: Bool?
 
     static func staticInit(dictionary: [String: Any]) -> BCOVPulseVideoItem {
         let videoItem = BCOVPulseVideoItem()
 
         videoItem.title = dictionary["content-title"] as? String ?? ""
         videoItem.category = dictionary["category"] as? String
-        videoItem.tags = dictionary["tags"] as? Array<String>
-        videoItem.midrollPositions = dictionary["midroll-positions"] as? Array<NSNumber>
+        videoItem.tags = dictionary["tags"] as? [String]
+        videoItem.midrollPositions = dictionary["midroll-positions"] as? [NSNumber]
         videoItem.extendSession = dictionary["extend-session"] as? Bool
 
         return videoItem

--- a/Pulse/BasicPulsePlayer-iOS/BasicPulsePlayer/ViewController.swift
+++ b/Pulse/BasicPulsePlayer-iOS/BasicPulsePlayer/ViewController.swift
@@ -183,7 +183,7 @@ final class ViewController: UIViewController {
     fileprivate var videoItem: BCOVPulseVideoItem?
     fileprivate var video: BCOVVideo?
 
-    fileprivate lazy var statusBarHidden = false {
+    fileprivate var statusBarHidden = false {
         didSet {
             setNeedsStatusBarAppearanceUpdate()
         }
@@ -216,7 +216,7 @@ final class ViewController: UIViewController {
                     case .restricted:
                         print("Restricted Tracking Permission")
                     @unknown default:
-                        print("Default value Trackin Permission")
+                        print("Default value Tracking Permission")
                 }
 
                 print("IDFA: \(ASIdentifierManager.shared().advertisingIdentifier.uuidString)")
@@ -263,16 +263,11 @@ final class ViewController: UIViewController {
 extension ViewController: BCOVPlaybackControllerDelegate {
 
     func playbackController(_ controller: BCOVPlaybackController!,
-                            didAdvanceTo session: BCOVPlaybackSession!) {
-        print("ViewController - Advanced to new session.")
-    }
-
-    func playbackController(_ controller: BCOVPlaybackController!,
                             playbackSession session: BCOVPlaybackSession,
                             didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {
 
         if kBCOVPlaybackSessionLifecycleEventFail == lifecycleEvent.eventType,
-           let error = lifecycleEvent.properties["error"] as? NSError {
+           let error = lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError] as? NSError {
             // Report any errors that may have occurred with playback.
             print("ViewController - Playback error: \(error.localizedDescription)")
         }
@@ -321,7 +316,7 @@ extension ViewController: BCOVPUIPlayerViewDelegate {
 }
 
 
-// MARK: - BCOVPlaybackControllerDelegate
+// MARK: - BCOVPulsePlaybackSessionDelegate
 
 extension ViewController: BCOVPulsePlaybackSessionDelegate {
 
@@ -355,9 +350,9 @@ extension ViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView,
                    cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let videoCell = tableView.dequeueReusableCell(withIdentifier: "VideoTableViewCell",
-                                                      for: indexPath) as UITableViewCell
+                                                      for: indexPath)
 
-        let item = videoItems[indexPath.item]
+        let item = videoItems[indexPath.row]
 
         videoCell.textLabel?.text = item.title ?? ""
         videoCell.textLabel?.textColor = .black

--- a/Pulse/BasicPulsePlayer-tvOS/BasicPulsePlayer/AppDelegate.swift
+++ b/Pulse/BasicPulsePlayer-tvOS/BasicPulsePlayer/AppDelegate.swift
@@ -9,7 +9,7 @@ import AVFoundation
 import UIKit
 
 
-@UIApplicationMain
+@main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/Pulse/BasicPulsePlayer-tvOS/BasicPulsePlayer/ViewController.swift
+++ b/Pulse/BasicPulsePlayer-tvOS/BasicPulsePlayer/ViewController.swift
@@ -45,7 +45,7 @@ final class ViewController: UIViewController {
         return playerView
     }()
 
-    fileprivate lazy var  playbackController: BCOVPlaybackController? = {
+    fileprivate lazy var playbackController: BCOVPlaybackController? = {
         /**
          *  Initialize the Brightcove Pulse Plugin.
          *  Host:
@@ -114,7 +114,7 @@ final class ViewController: UIViewController {
     }()
 
     override var preferredFocusEnvironments: [UIFocusEnvironment] {
-        return [playerView?.controlsView ?? self]
+        [playerView?.controlsView ?? self]
     }
 
     override func viewDidLoad() {
@@ -140,7 +140,7 @@ final class ViewController: UIViewController {
                     case .restricted:
                         print("Restricted Tracking Permission")
                     @unknown default:
-                        print("Default value Trackin Permission")
+                        print("Default value Tracking Permission")
                 }
 
                 print("IDFA: \(ASIdentifierManager.shared().advertisingIdentifier.uuidString)")
@@ -212,16 +212,11 @@ final class ViewController: UIViewController {
 extension ViewController: BCOVPlaybackControllerDelegate {
 
     func playbackController(_ controller: BCOVPlaybackController!,
-                            didAdvanceTo session: BCOVPlaybackSession!) {
-        print("ViewController - Advanced to new session.")
-    }
-
-    func playbackController(_ controller: BCOVPlaybackController!,
                             playbackSession session: BCOVPlaybackSession,
                             didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {
 
         if kBCOVPlaybackSessionLifecycleEventFail == lifecycleEvent.eventType,
-           let error = lifecycleEvent.properties["error"] as? NSError {
+           let error = lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError] as? NSError {
             // Report any errors that may have occurred with playback.
             print("ViewController - Playback error: \(error.localizedDescription)")
         }

--- a/SSAI/BasicSSAIPlayer-iOS/BasicSSAIPlayer/AppDelegate.swift
+++ b/SSAI/BasicSSAIPlayer-iOS/BasicSSAIPlayer/AppDelegate.swift
@@ -9,7 +9,7 @@ import AVFoundation
 import UIKit
 
 
-@UIApplicationMain
+@main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/SSAI/BasicSSAIPlayer-iOS/BasicSSAIPlayer/ViewController.swift
+++ b/SSAI/BasicSSAIPlayer-iOS/BasicSSAIPlayer/ViewController.swift
@@ -10,7 +10,6 @@ import AppTrackingTransparency
 import UIKit
 import BrightcoveSSAI
 //import OMSDK_Brightcove
-//import ProgrammaticAccessLibrary
 
 
 // Customize these values with your own account information
@@ -111,24 +110,14 @@ final class ViewController: UIViewController {
     // to create a BCOVVideo instead
     fileprivate let useVMAPURL = false
 
-    // When this value is set to YES the PAL SDK
-    // will be used in conjuction with the Brightcove SSAI plugin
-    fileprivate let usePAL = false
-
-    // If using PAL SDK uncomment these properties
-//    fileprivate var didSendPlaybackStart = false
-//    fileprivate var nonceLoader: NonceLoader?
-//    fileprivate var nonceManager: NonceManager?
-//    fileprivate var PALNonce: String?
-
-    fileprivate lazy var statusBarHidden = false {
+    fileprivate var statusBarHidden = false {
         didSet {
             setNeedsStatusBarAppearanceUpdate()
         }
     }
 
     override var prefersStatusBarHidden: Bool {
-        return statusBarHidden
+        statusBarHidden
     }
 
     override func viewDidLoad() {
@@ -142,12 +131,7 @@ final class ViewController: UIViewController {
 
     @objc
     fileprivate func applicationDidBecomeActive(_ notification: NSNotification) {
-        if usePAL {
-            // If using PAL SDK uncomment this line
-//            setUpPAL()
-        } else {
-            requestTrackingAuthorization()
-        }
+        requestTrackingAuthorization()
 
         NotificationCenter.default.removeObserver(self,
                                                   name: UIApplication.didBecomeActiveNotification,
@@ -167,7 +151,7 @@ final class ViewController: UIViewController {
                     case .restricted:
                         print("Restricted Tracking Permission")
                     @unknown default:
-                        print("Default value Trackin Permission")
+                        print("Default value Tracking Permission")
                 }
 
                 print("IDFA: \(ASIdentifierManager.shared().advertisingIdentifier.uuidString)")
@@ -270,13 +254,6 @@ final class ViewController: UIViewController {
                 return
             }
 #endif
-            // If using PAL SDK uncomment this block
-//            if self.usePAL {
-//                if let jsonResponse = jsonResponse {
-//                    let updatedJSON = self.appendPALNonce(forJSON: jsonResponse)
-//                    video = BCOVPlaybackService.video(fromJSONDictionary: updatedJSON)
-//                }
-//            }
             playbackController.setVideos([video])
         }
     }
@@ -288,31 +265,14 @@ final class ViewController: UIViewController {
 extension ViewController: BCOVPlaybackControllerDelegate {
 
     func playbackController(_ controller: BCOVPlaybackController!,
-                            didAdvanceTo session: BCOVPlaybackSession!) {
-        print("ViewController - Advanced to new session.")
-    }
-
-    func playbackController(_ controller: BCOVPlaybackController!,
-                            playbackSession session: BCOVPlaybackSession,
+                            playbackSession session: BCOVPlaybackSession!,
                             didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {
 
         if kBCOVPlaybackSessionLifecycleEventFail == lifecycleEvent.eventType,
-           let error = lifecycleEvent.properties["error"] as? NSError {
+           let error = lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError] as? NSError {
             // Report any errors that may have occurred with playback.
             print("ViewController - Playback error: \(error.localizedDescription)")
         }
-
-        // If using PAL SDK uncomment this block
-//        if usePAL {
-//            if lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventPlay && !didSendPlaybackStart {
-//                didSendPlaybackStart = true
-//                nonceManager?.sendPlaybackStart()
-//            }
-//
-//            if lifecycleEvent.eventType == kBCOVPlaybackSessionLifecycleEventEnd {
-//                nonceManager?.sendPlaybackEnd()
-//            }
-//        }
     }
 }
 
@@ -345,7 +305,6 @@ extension ViewController: BCOVPlaybackControllerAdsDelegate {
     }
 }
 
-
 // MARK: - BCOVPUIPlayerViewDelegate
 
 extension ViewController: BCOVPUIPlayerViewDelegate {
@@ -354,86 +313,4 @@ extension ViewController: BCOVPUIPlayerViewDelegate {
                     willTransitionTo screenMode: BCOVPUIScreenMode) {
         statusBarHidden = screenMode == .full
     }
-
-    func willOpenExternalBrowser(with ad: BCOVAd!) {
-        if usePAL {
-            // If using PAL SDK uncomment this line
-//            nonceManager?.sendAdClick()
-        }
-    }
 }
-
-// MARK: - PAL Integration
-// If using PAL SDK uncomment these methods
-
-//extension ViewController {
-//
-//    func setUpPAL() {
-//        // The default value for 'allowStorage' and 'directedForChildOrUnknownAge' is
-//        // 'NO', but should be updated once the appropriate consent has been gathered.
-//        // Publishers should either integrate with a CMP or use a different method to
-//        // handle storage consent.
-//        let settings = Settings()
-//        settings.allowStorage = true
-//        settings.directedForChildOrUnknownAge = false
-//
-//        nonceLoader = NonceLoader(settings: settings)
-//        nonceLoader?.delegate = self
-//
-//        requestNonceManager()
-//    }
-//
-//    func requestNonceManager() {
-//        // See https://developers.google.com/ad-manager/pal/ios/reference/Classes/PALNonceRequest
-//        // for all possible configurations.
-//        let request = NonceRequest()
-//        request.continuousPlayback = Flag.off
-//        request.playerType = "BasicSSAIPlayer"
-//        request.playerVersion = "1.0.0"
-//        request.sessionID = NSUUID().uuidString
-//        request.willAdAutoPlay = Flag.on
-//        request.willAdPlayMuted = Flag.off
-//
-//        nonceLoader?.loadNonceManager(with: request)
-//    }
-//
-//    func appendPALNonce(forJSON json: [AnyHashable: Any]) -> [AnyHashable: Any] {
-//        guard let sources = json["sources"] as? [[AnyHashable:Any]] else {
-//            return json
-//        }
-//        var updatedJson = json
-//        var updatedSources = [[AnyHashable:Any]]()
-//        for source in sources {
-//            guard var vmapURL = source["vmap"] as? String, let PALNonce = PALNonce else {
-//                continue
-//            }
-//            vmapURL = "\(vmapURL)&givn=\(PALNonce)"
-//            var updatedSource = source
-//            updatedSource["vmap"] = vmapURL
-//            updatedSources.append(updatedSource)
-//        }
-//        updatedJson["sources"] = updatedSources
-//        return updatedJson
-//    }
-//
-//}
-
-// MARK: - PAL Integration
-// If using PAL SDK uncomment these methods
-
-//extension ViewController: NonceLoaderDelegate {
-//
-//    func nonceLoader(_ nonceLoader: NonceLoader, with request: NonceRequest, didLoad nonceManager: NonceManager) {
-//        print("Programmatic access nonce: \(nonceManager.nonce)")
-//        // Capture the created nonce manager and attach its gesture recognizer to the video view.
-//        self.nonceManager = nonceManager
-//
-//        PALNonce = nonceManager.nonce
-//
-//        videoSetUp()
-//    }
-//
-//    func nonceLoader(_ nonceLoader: NonceLoader, with request: NonceRequest, didFailWith error: any Error) {
-//        print("Error generating programmatic access nonce: \(error)")
-//    }
-//}

--- a/SSAI/BasicSSAIPlayer-iOS/README.md
+++ b/SSAI/BasicSSAIPlayer-iOS/README.md
@@ -9,8 +9,8 @@ Basic Dynamic Delivery SSAI playback: the sample chains a Brightcove SSAI sessio
 | `BasicSSAIPlayer/ViewController.swift` | SSAI session provider, content request with the ad-config id, companion slot |
 | `BasicSSAIPlayer/AppDelegate.swift` | Configures `AVAudioSession` for playback |
 
-## Optional: Open Measurement and PAL
+## Optional: Open Measurement
 
-The project links the Open Measurement product for IAB viewability and includes commented-out scaffolding for Google's PAL SDK. Both are opt-in and off by default. For setup — the OMID partner signature, the VAST 4.1 ad-verification requirements, and adding the PAL SDK — see the [Brightcove Player SDK for iOS](https://github.com/brightcove/brightcove-player-sdk-ios) documentation.
+The project links the Open Measurement product for IAB viewability. It is opt-in and off by default. For setup — the OMID partner signature and the VAST 4.1 ad-verification requirements — see the [Brightcove Player SDK for iOS](https://github.com/brightcove/brightcove-player-sdk-ios) documentation.
 
 See the [SSAI README](../) for shared setup.

--- a/SSAI/BasicSSAIPlayer-tvOS/BasicSSAIPlayer/AppDelegate.swift
+++ b/SSAI/BasicSSAIPlayer-tvOS/BasicSSAIPlayer/AppDelegate.swift
@@ -9,7 +9,7 @@ import AVFoundation
 import UIKit
 
 
-@UIApplicationMain
+@main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/SSAI/BasicSSAIPlayer-tvOS/BasicSSAIPlayer/ViewController.swift
+++ b/SSAI/BasicSSAIPlayer-tvOS/BasicSSAIPlayer/ViewController.swift
@@ -5,6 +5,21 @@
 //  Copyright © 2026 Brightcove, Inc. All rights reserved.
 //
 
+/*
+ * This sample app shows how to play Server-Side Ad Insertion (SSAI) content on
+ * tvOS using Dynamic Delivery.
+ *
+ * An SSAI session provider is created with
+ * `BCOVPlayerSDKManager.createSSAISessionProvider(withUpstreamSessionProvider:)`
+ * and chained on top of a FairPlay session provider, then used as the session
+ * provider for the playback controller. The ad-configuration id is supplied as
+ * a query parameter (`BCOVPlaybackService.ParamaterKeyAdConfigId`) when the
+ * video is requested, and playback is presented through `BCOVTVPlayerView`.
+ *
+ * Because SSAI relies on ad tracking, the app requests App Tracking
+ * Transparency authorization before loading content.
+ */
+
 import AdSupport
 import AppTrackingTransparency
 import UIKit
@@ -30,8 +45,6 @@ final class ViewController: UIViewController {
     fileprivate lazy var playerView: BCOVTVPlayerView? = {
         let options = BCOVTVPlayerViewOptions()
         options.presentingViewController = self
-        //options.hideControlsInterval = 3000
-        //options.hideControlsAnimationDuration = 0.2
 
         guard let playerView = BCOVTVPlayerView(options: options) else {
             return nil
@@ -71,7 +84,7 @@ final class ViewController: UIViewController {
     }()
 
     override var preferredFocusEnvironments: [UIFocusEnvironment] {
-        return [playerView?.controlsView ?? self]
+        [playerView?.controlsView ?? self]
     }
 
     override func viewDidLoad() {
@@ -97,7 +110,7 @@ final class ViewController: UIViewController {
                     case .restricted:
                         print("Restricted Tracking Permission")
                     @unknown default:
-                        print("Default value Trackin Permission")
+                        print("Default value Tracking Permission")
                 }
 
                 print("IDFA: \(ASIdentifierManager.shared().advertisingIdentifier.uuidString)")
@@ -171,16 +184,11 @@ final class ViewController: UIViewController {
 extension ViewController: BCOVPlaybackControllerDelegate {
 
     func playbackController(_ controller: BCOVPlaybackController!,
-                            didAdvanceTo session: BCOVPlaybackSession!) {
-        print("ViewController - Advanced to new session.")
-    }
-
-    func playbackController(_ controller: BCOVPlaybackController!,
                             playbackSession session: BCOVPlaybackSession,
                             didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {
 
         if kBCOVPlaybackSessionLifecycleEventFail == lifecycleEvent.eventType,
-           let error = lifecycleEvent.properties["error"] as? NSError {
+           let error = lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError] as? NSError {
             // Report any errors that may have occurred with playback.
             print("ViewController - Playback error: \(error.localizedDescription)")
         }

--- a/SSAI/README.md
+++ b/SSAI/README.md
@@ -22,7 +22,7 @@ The samples request App Tracking Transparency authorization and enable arbitrary
 
 | Sample | Platform | What it demonstrates |
 |---|---|---|
-| [`BasicSSAIPlayer-iOS`](BasicSSAIPlayer-iOS/) | iOS | Dynamic Delivery SSAI VOD playback with companion ad slots; optional Open Measurement and Google PAL |
+| [`BasicSSAIPlayer-iOS`](BasicSSAIPlayer-iOS/) | iOS | Dynamic Delivery SSAI VOD playback with companion ad slots; optional Open Measurement |
 | [`BasicSSAIPlayer-tvOS`](BasicSSAIPlayer-tvOS/) | tvOS | The same SSAI playback on tvOS with `BCOVTVPlayerView` |
 | [`SLS-IMA-iOS`](SLS-IMA-iOS/) | iOS | Client-side Google IMA ads (a VMAP tag) layered on SSAI, for a Server-Side Live + IMA workflow |
 | [`SLS-IMA-tvOS`](SLS-IMA-tvOS/) | tvOS | The same IMA-over-SSAI chain on tvOS |

--- a/SSAI/SLS-IMA-iOS/SLS_IMA-Player/AppDelegate.swift
+++ b/SSAI/SLS-IMA-iOS/SLS_IMA-Player/AppDelegate.swift
@@ -9,7 +9,7 @@ import AVFoundation
 import UIKit
 
 
-@UIApplicationMain
+@main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/SSAI/SLS-IMA-iOS/SLS_IMA-Player/ViewController.swift
+++ b/SSAI/SLS-IMA-iOS/SLS_IMA-Player/ViewController.swift
@@ -5,6 +5,24 @@
 //  Copyright © 2026 Brightcove, Inc. All rights reserved.
 //
 
+/*
+ * This sample app shows how to layer client-side Google IMA ads (a VMAP tag) on
+ * top of server-side ad insertion (SSAI), for a Server-Side Live + IMA workflow.
+ *
+ * The playback controller is built from a chain of session providers created by
+ * `BCOVPlayerSDKManager`. A FairPlay provider is the base; it is the upstream of
+ * the IMA provider, which is in turn the upstream of the SSAI provider. The SSAI
+ * provider is handed to the playback controller, so each session flows
+ * FairPlay → IMA → SSAI.
+ *
+ * `BCOVIMAAdsRequestPolicy(vmapAdTagUrl:)` selects a VMAP / Server Side Ad Rules
+ * policy for the IMA ads, and `BCOVIMAPlaybackSessionDelegate` lets the sample
+ * adjust each `IMAAdsRequest` before ads are loaded.
+ *
+ * FairPlay content can only be decrypted on physical devices, so the sample
+ * detects the simulator and displays a warning instead of playing.
+ */
+
 import AdSupport
 import AppTrackingTransparency
 import UIKit
@@ -59,14 +77,14 @@ final class ViewController: UIViewController {
                                                          applicationId: nil)
 
         let imaSettings = IMASettings()
-        imaSettings.language = NSLocale.current.languageCode!
+        imaSettings.language = NSLocale.current.languageCode ?? "en"
 
         let renderSettings = IMAAdsRenderingSettings()
         renderSettings.linkOpenerPresentingController = self
         renderSettings.linkOpenerDelegate = self
 
         // BCOVIMAAdsRequestPolicy provides methods to specify VAST or VMAP/Server Side Ad Rules. Select the appropriate method to select your ads policy.
-        let adsRequestPolicy = BCOVIMAAdsRequestPolicy.init(vmapAdTagUrl: kViewControllerVMAPAdTagURL)
+        let adsRequestPolicy = BCOVIMAAdsRequestPolicy(vmapAdTagUrl: kViewControllerVMAPAdTagURL)
 
         // BCOVIMAPlaybackSessionDelegate defines -willCallIMAAdsLoaderRequestAdsWithRequest:forPosition:
         // which allows us to modify the IMAAdsRequest object before it is used to load ads.
@@ -102,14 +120,14 @@ final class ViewController: UIViewController {
         return playbackController
     }()
 
-    fileprivate lazy var statusBarHidden = false {
+    fileprivate var statusBarHidden = false {
         didSet {
             setNeedsStatusBarAppearanceUpdate()
         }
     }
 
     override var prefersStatusBarHidden: Bool {
-        return statusBarHidden
+        statusBarHidden
     }
 
     override func viewDidLoad() {
@@ -135,7 +153,7 @@ final class ViewController: UIViewController {
                     case .restricted:
                         print("Restricted Tracking Permission")
                     @unknown default:
-                        print("Default value Trackin Permission")
+                        print("Default value Tracking Permission")
                 }
 
                 print("IDFA: \(ASIdentifierManager.shared().advertisingIdentifier.uuidString)")
@@ -208,16 +226,11 @@ final class ViewController: UIViewController {
 extension ViewController: BCOVPlaybackControllerDelegate {
 
     func playbackController(_ controller: BCOVPlaybackController!,
-                            didAdvanceTo session: BCOVPlaybackSession!) {
-        print("ViewController - Advanced to new session.")
-    }
-
-    func playbackController(_ controller: BCOVPlaybackController!,
                             playbackSession session: BCOVPlaybackSession,
                             didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {
 
         if kBCOVPlaybackSessionLifecycleEventFail == lifecycleEvent.eventType,
-           let error = lifecycleEvent.properties["error"] as? NSError {
+           let error = lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError] as? NSError {
             // Report any errors that may have occurred with playback.
             print("ViewController - Playback error: \(error.localizedDescription)")
         }

--- a/SSAI/SLS-IMA-tvOS/SLS_IMA-Player/AppDelegate.swift
+++ b/SSAI/SLS-IMA-tvOS/SLS_IMA-Player/AppDelegate.swift
@@ -9,7 +9,7 @@ import AVFoundation
 import UIKit
 
 
-@UIApplicationMain
+@main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/SSAI/SLS-IMA-tvOS/SLS_IMA-Player/ViewController.swift
+++ b/SSAI/SLS-IMA-tvOS/SLS_IMA-Player/ViewController.swift
@@ -23,6 +23,9 @@ let kAdConfigId = "insertyouradconfigidhere"
 let kViewControllerVMAPAdTagURL = "insertyouradtaghere"
 
 
+/// Plays Server-Side Live (SLS) content with IMA ads on tvOS, chaining the
+/// session providers FairPlay → IMA → SSAI and requesting ads from a VMAP tag
+/// through `BCOVTVPlayerView`.
 final class ViewController: UIViewController {
 
     fileprivate lazy var playbackService: BCOVPlaybackService = {
@@ -53,13 +56,13 @@ final class ViewController: UIViewController {
                                                          applicationId: nil)
 
         let imaSettings = IMASettings()
-        imaSettings.language = NSLocale.current.languageCode!
+        imaSettings.language = NSLocale.current.languageCode ?? "en"
 
         let renderSettings = IMAAdsRenderingSettings()
         renderSettings.linkOpenerPresentingController = self
 
         // BCOVIMAAdsRequestPolicy provides methods to specify VAST or VMAP/Server Side Ad Rules. Select the appropriate method to select your ads policy.
-        let adsRequestPolicy = BCOVIMAAdsRequestPolicy.init(vmapAdTagUrl: kViewControllerVMAPAdTagURL)
+        let adsRequestPolicy = BCOVIMAAdsRequestPolicy(vmapAdTagUrl: kViewControllerVMAPAdTagURL)
 
         // BCOVIMAPlaybackSessionDelegate defines -willCallIMAAdsLoaderRequestAdsWithRequest:forPosition:
         // which allows us to modify the IMAAdsRequest object before it is used to load ads.
@@ -96,7 +99,7 @@ final class ViewController: UIViewController {
     }()
 
     override var preferredFocusEnvironments: [UIFocusEnvironment] {
-        return [playerView?.controlsView ?? self]
+        [playerView?.controlsView ?? self]
     }
 
     override func viewDidLoad() {
@@ -122,7 +125,7 @@ final class ViewController: UIViewController {
                     case .restricted:
                         print("Restricted Tracking Permission")
                     @unknown default:
-                        print("Default value Trackin Permission")
+                        print("Default value Tracking Permission")
                 }
 
                 print("IDFA: \(ASIdentifierManager.shared().advertisingIdentifier.uuidString)")
@@ -196,16 +199,11 @@ final class ViewController: UIViewController {
 extension ViewController: BCOVPlaybackControllerDelegate {
 
     func playbackController(_ controller: BCOVPlaybackController!,
-                            didAdvanceTo session: BCOVPlaybackSession!) {
-        print("ViewController - Advanced to new session.")
-    }
-
-    func playbackController(_ controller: BCOVPlaybackController!,
                             playbackSession session: BCOVPlaybackSession,
                             didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {
 
         if kBCOVPlaybackSessionLifecycleEventFail == lifecycleEvent.eventType,
-           let error = lifecycleEvent.properties["error"] as? NSError {
+           let error = lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError] as? NSError {
             // Report any errors that may have occurred with playback.
             print("ViewController - Playback error: \(error.localizedDescription)")
         }

--- a/SharePlay/SharePlayPlayer/AppDelegate.swift
+++ b/SharePlay/SharePlayPlayer/AppDelegate.swift
@@ -9,7 +9,7 @@ import AVFoundation
 import UIKit
 
 
-@UIApplicationMain
+@main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?

--- a/SharePlay/SharePlayPlayer/ViewController.swift
+++ b/SharePlay/SharePlayPlayer/ViewController.swift
@@ -5,6 +5,23 @@
 //  Copyright © 2026 Brightcove, Inc. All rights reserved.
 //
 
+/*
+ * This sample app shows how to play a Video Cloud video together with remote
+ * participants using SharePlay.
+ *
+ * `WatchTogether` is the `GroupActivity` shared with the group. When the user
+ * starts SharePlay, `WatchTogetherWrapper.activateNewActivity(withVideo:withSource:)`
+ * advertises it; the wrapper then listens for the resulting `GroupSession`,
+ * joins it, and hands the video's source URL to every participant so each
+ * device plays the same content.
+ *
+ * Synchronized playback is driven by AVPlayer's playback coordinator:
+ * `WatchTogetherWrapper` registers as a `BCOVPlaybackSessionConsumer` to obtain
+ * the session's `AVPlayer`, then calls
+ * `player.playbackCoordinator.coordinateWithSession(_:)` so play, pause, and
+ * seek stay in sync across the group.
+ */
+
 import UIKit
 import BrightcovePlayerSDK
 
@@ -97,14 +114,14 @@ final class ViewController: UIViewController {
 
     fileprivate var playWithSharePlay = false
 
-    fileprivate lazy var statusBarHidden = false {
+    fileprivate var statusBarHidden = false {
         didSet {
             setNeedsStatusBarAppearanceUpdate()
         }
     }
 
     override var prefersStatusBarHidden: Bool {
-        return statusBarHidden
+        statusBarHidden
     }
 
     override func viewDidLoad() {
@@ -155,13 +172,11 @@ final class ViewController: UIViewController {
 
             if playWithSharePlay {
                 if let source = sourceSelectionPolicy(video) {
-                    print("ViewController - Playing video with SharePlay")
                     watchTogether.activateNewActivity(withVideo: video,
                                                       withSource: source)
                 }
             } else {
                 if let playbackController {
-                    print("ViewController - Playing video locally")
                     playbackController.setVideos([video])
                 }
             }
@@ -199,8 +214,6 @@ final class ViewController: UIViewController {
 extension ViewController: WatchTogetherWrapperDelegate {
 
     func groupSessionWasJoined() {
-        print("ViewController - Activity was Joined")
-
         DispatchQueue.main.async { [self] in
             updateSessionLabel(withStatus: "Joined")
             endSharePlayButton.isEnabled = true
@@ -208,8 +221,6 @@ extension ViewController: WatchTogetherWrapperDelegate {
     }
 
     func groupSessionWasInvalidated() {
-        print("ViewController - Activity was Invalidated")
-
         DispatchQueue.main.async { [self] in
             updateSessionLabel(withStatus: "Inactive")
             endSharePlayButton.isEnabled = false
@@ -217,8 +228,6 @@ extension ViewController: WatchTogetherWrapperDelegate {
     }
 
     func activityWasDisabled() {
-        print("ViewController - Activity was Disabled or No Activity Active")
-
         DispatchQueue.main.async { [self] in
             updateSessionLabel(withStatus: "Inactive")
             endSharePlayButton.isEnabled = false
@@ -240,16 +249,11 @@ extension ViewController: WatchTogetherWrapperDelegate {
 extension ViewController: BCOVPlaybackControllerDelegate {
 
     func playbackController(_ controller: BCOVPlaybackController!,
-                            didAdvanceTo session: BCOVPlaybackSession!) {
-        print("ViewController - Advanced to new session.")
-    }
-
-    func playbackController(_ controller: BCOVPlaybackController!,
                             playbackSession session: BCOVPlaybackSession,
                             didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {
 
         if kBCOVPlaybackSessionLifecycleEventFail == lifecycleEvent.eventType,
-           let error = lifecycleEvent.properties["error"] as? NSError {
+           let error = lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError] as? NSError {
             // Report any errors that may have occurred with playback.
             print("ViewController - Playback error: \(error.localizedDescription)")
         }

--- a/SharePlay/SharePlayPlayer/WatchTogetherWrapper.swift
+++ b/SharePlay/SharePlayPlayer/WatchTogetherWrapper.swift
@@ -37,6 +37,7 @@ final class WatchTogetherWrapper: NSObject {
     weak var playbackController: BCOVPlaybackController?
 
     fileprivate var subscriptions = [AnyCancellable]()
+    fileprivate var listenerTask: Task<Void, Never>?
     fileprivate var watchTogether: WatchTogether?
     fileprivate var result: GroupActivityActivationResult?
     fileprivate var groupSession: GroupSession<WatchTogether>? {
@@ -84,10 +85,11 @@ final class WatchTogetherWrapper: NSObject {
             let result = await watchTogether.prepareForActivation()
             switch result {
                 case .activationPreferred:
-                    let didActivate = try await watchTogether.activate()
-                    if didActivate {
-                        delegate?.activityWasActivated()
-                    } else {
+                    do {
+                        let didActivate = try await watchTogether.activate()
+                        didActivate ? delegate?.activityWasActivated() : delegate?.activityFailedActivation()
+                    } catch {
+                        print("WatchTogetherWrapper - activation error: \(error.localizedDescription)")
                         delegate?.activityFailedActivation()
                     }
                     break
@@ -106,14 +108,20 @@ final class WatchTogetherWrapper: NSObject {
         }
     }
 
+    deinit {
+        listenerTask?.cancel()
+    }
+
     fileprivate func startListening() {
-        Task.init(priority: TaskPriority.background) {
+        listenerTask = Task(priority: .background) { [weak self] in
             for await groupSession in WatchTogether.sessions() {
+                guard let self else { return }
+
                 // Set the app's active group session.
                 self.groupSession = groupSession
 
                 // Remove previous subscriptions.
-                subscriptions.removeAll()
+                self.subscriptions.removeAll()
 
                 // Observe changes to the session state.
                 groupSession.$state.sink { [weak self] state in
@@ -134,7 +142,7 @@ final class WatchTogetherWrapper: NSObject {
                         self?.delegate?.groupSessionWasJoined()
                     }
 
-                }.store(in: &subscriptions)
+                }.store(in: &self.subscriptions)
 
                 // Observe when the local user or a remote participant starts an activity.
                 groupSession.$activity.sink { [playbackController] activity in
@@ -163,7 +171,7 @@ final class WatchTogetherWrapper: NSObject {
 
                     }
 
-                }.store(in: &subscriptions)
+                }.store(in: &self.subscriptions)
             }
         }
     }

--- a/SwiftUI/CustomControls/CustomControls/Double+Extensions.swift
+++ b/SwiftUI/CustomControls/CustomControls/Double+Extensions.swift
@@ -12,7 +12,7 @@ import UIKit
 extension Double {
 
     var asCMTime: CMTime {
-        return CMTime(seconds: self,
-                      preferredTimescale: CMTimeScale(60))
+        CMTime(seconds: self,
+               preferredTimescale: CMTimeScale(60))
     }
 }

--- a/SwiftUI/CustomControls/CustomControls/Models/PlayerModel.swift
+++ b/SwiftUI/CustomControls/CustomControls/Models/PlayerModel.swift
@@ -80,8 +80,7 @@ extension PlayerModel: BCOVPlaybackControllerDelegate {
 
     func playbackController(_ controller: BCOVPlaybackController!,
                             didAdvanceTo session: BCOVPlaybackSession!) {
-        print("ViewController - Advanced to new session.")
-        if let player = session.player , let item = player.currentItem,
+        if let player = session.player, let item = player.currentItem,
            item.responds(to: NSSelectorFromString("preferredForwardBufferDuration")) {
             guard session.player != nil else { return }
             buffer = availableDuration(player: player)
@@ -120,18 +119,6 @@ extension PlayerModel: BCOVPlaybackControllerDelegate {
                 isPlaying = false
                 timer?.invalidate()
                 showControls = true
-            case kBCOVPlaybackSessionLifecycleEventResumeFail:
-                print("resumeFail")
-            case kBCOVPlaybackSessionLifecycleEventResumeBegin:
-                print("play")
-            case kBCOVPlaybackSessionLifecycleEventFail:
-                print("failedToLoad")
-            case kBCOVPlaybackSessionLifecycleEventError:
-                print("error")
-            case kBCOVPlaybackSessionLifecycleEventPlaybackBufferEmpty:
-                print("bufferEmpty")
-            case kBCOVPlaybackSessionLifecycleEventPlaybackLikelyToKeepUp:
-                print("likelyToKeepUp")
             default: break
         }
     }

--- a/SwiftUI/CustomControls/CustomControls/Models/ThumbnailManager.swift
+++ b/SwiftUI/CustomControls/CustomControls/Models/ThumbnailManager.swift
@@ -56,7 +56,7 @@ final class ThumbnailManager {
 
             session.dataTask(with: url) { data, response, error in
                 guard let data,
-                      error == nil else { return }
+                      error == nil else { promise(.failure(.fetchError)); return }
 
                 DispatchQueue.main.async { [self] in
                     guard let image = UIImage(data: data) else {

--- a/SwiftUI/CustomControls/CustomControls/Models/ThumbnailManager.swift
+++ b/SwiftUI/CustomControls/CustomControls/Models/ThumbnailManager.swift
@@ -22,7 +22,7 @@ final class ThumbnailManager {
     fileprivate var cancellables = [AnyCancellable]()
     fileprivate let cache = NSCache<NSString, UIImage>()
 
-    fileprivate lazy var thumbnails: [ThumbnailModel] = .init()
+    fileprivate var thumbnails: [ThumbnailModel] = .init()
     fileprivate lazy var session: URLSession = URLSession(configuration: .default)
 
     init(url: URL) {
@@ -117,8 +117,8 @@ fileprivate extension ThumbnailManager {
                 let regex = try NSRegularExpression(pattern: "([0-9]{2}):([0-9]{2}).([0-9]{3}) --> ([0-9]{2}):([0-9]{2}).([0-9]{3})",
                                                     options: .caseInsensitive)
                 let matches = regex.matches(in: line,
-                                            options: NSRegularExpression.MatchingOptions(rawValue: 0),
-                                            range: NSMakeRange(0, line.count))
+                                            options: [],
+                                            range: NSRange(location: 0, length: line.count))
                 if matches.count == 1 {
                     if let result = matches.first {
                         let startTimeMinuteRange = result.range(at: 1)
@@ -133,7 +133,7 @@ fileprivate extension ThumbnailManager {
                               let endTimeMinute = Double((line as NSString).substring(with: endTimeMinuteRange)),
                               let endTimeSecond = Double((line as NSString).substring(with: endTimeSecondRange)),
                               let endTimeMS = Double((line as NSString).substring(with: endTimeMSRange)) else {
-                            break;
+                            break
                         }
 
                         let startTime = (startTimeMinute * 60.0 * 60.0) + (startTimeSecond * 60) + (startTimeMS / 1000)
@@ -150,7 +150,7 @@ fileprivate extension ThumbnailManager {
                     }
                 }
 
-                if matches.count == 0 && line.count > 0 {
+                if matches.isEmpty && !line.isEmpty {
                     if let currentThumbnail = thumbnails.last {
                         guard let urlParse = URL(string: line) else {
                             break

--- a/SwiftUI/CustomControls/CustomControls/Models/VideoModel.swift
+++ b/SwiftUI/CustomControls/CustomControls/Models/VideoModel.swift
@@ -24,7 +24,7 @@ final class VideoModel {
     }()
 
     func requestContentFromPlaybackService() -> Future<BCOVVideo, Error> {
-        return Future<BCOVVideo, Error> { [self] promise in
+        Future<BCOVVideo, Error> { [self] promise in
             let configuration = [BCOVPlaybackService.ConfigurationKeyAssetID: kVideoId]
 
             playbackService.findVideo(withConfiguration: configuration,

--- a/SwiftUI/CustomControls/CustomControls/TimeInterval+Extensions.swift
+++ b/SwiftUI/CustomControls/CustomControls/TimeInterval+Extensions.swift
@@ -11,17 +11,15 @@ import UIKit
 extension TimeInterval {
 
     var stringFromTime: String {
-        if isFinite {
-            let hours = Int(truncatingRemainder(dividingBy: 86_400) / 3_600)
-            let minutes = Int(truncatingRemainder(dividingBy: 3_600) / 60)
-            let seconds = Int(truncatingRemainder(dividingBy: 60))
-            if hours > 0 {
-                return String(format: "%i:%02i:%02i", hours, minutes, seconds)
-            } else {
-                return String(format: "%02i:%02i", minutes, seconds)
-            }
+        guard isFinite else { return "" }
+
+        let hours = Int(truncatingRemainder(dividingBy: 86_400) / 3_600)
+        let minutes = Int(truncatingRemainder(dividingBy: 3_600) / 60)
+        let seconds = Int(truncatingRemainder(dividingBy: 60))
+        if hours > 0 {
+            return String(format: "%i:%02i:%02i", hours, minutes, seconds)
         } else {
-            return ""
+            return String(format: "%02i:%02i", minutes, seconds)
         }
     }
 }

--- a/SwiftUI/CustomControls/CustomControls/UISlider+Extensions.swift
+++ b/SwiftUI/CustomControls/CustomControls/UISlider+Extensions.swift
@@ -11,7 +11,7 @@ import UIKit
 extension UISlider {
 
     var trackBounds: CGRect {
-        return trackRect(forBounds: bounds)
+        trackRect(forBounds: bounds)
     }
 
     var trackFrame: CGRect {
@@ -21,14 +21,14 @@ extension UISlider {
     }
 
     var thumbBounds: CGRect {
-        return thumbRect(forBounds: frame,
-                         trackRect: trackBounds,
-                         value: value)
+        thumbRect(forBounds: frame,
+                  trackRect: trackBounds,
+                  value: value)
     }
 
     var thumbFrame: CGRect {
-        return thumbRect(forBounds: bounds,
-                         trackRect: trackFrame,
-                         value: value)
+        thumbRect(forBounds: bounds,
+                  trackRect: trackFrame,
+                  value: value)
     }
 }

--- a/SwiftUI/CustomControls/CustomControls/Views/CustomControlsView.swift
+++ b/SwiftUI/CustomControls/CustomControls/Views/CustomControlsView.swift
@@ -36,9 +36,7 @@ struct CustomControlsView: View {
                     playbackController.seek(to: CMTime(seconds: playerModel.progress,
                                                        preferredTimescale: CMTimeScale(1.0)),
                                             toleranceBefore: .zero,
-                                            toleranceAfter: .zero) { sliderChangeValue in
-                        if sliderChangeValue { print("Slider progress changed") }
-                    }
+                                            toleranceAfter: .zero) { _ in }
                 } onTouchSliderEvent: { _, _, isTrack in
                     guard let playbackController = playerModel.playbackController else { return }
 
@@ -61,9 +59,7 @@ struct CustomControlsView: View {
                 Button {
                     guard let playbackController = playerModel.playbackController else { return }
                     playbackController.seek(to: CMTime(seconds: playerModel.progress - 10,
-                                                       preferredTimescale: CMTimeScale(1.0))) { back in
-                        if back { print("Back - 10 second") }
-                    }
+                                                       preferredTimescale: CMTimeScale(1.0))) { _ in }
                 } label: {
                     Image(systemName: "gobackward.10")
                         .resizable()
@@ -83,9 +79,7 @@ struct CustomControlsView: View {
                 Button {
                     guard let playbackController = playerModel.playbackController else { return }
                     playbackController.seek(to: CMTime(seconds: playerModel.progress + 10,
-                                                       preferredTimescale: CMTimeScale(1.0))) { next in
-                        if next { print("Next + 10 second") }
-                    }
+                                                       preferredTimescale: CMTimeScale(1.0))) { _ in }
                 } label: {
                     Image(systemName: "goforward.10")
                         .resizable()

--- a/SwiftUI/CustomControls/CustomControls/Views/CustomSliderView.swift
+++ b/SwiftUI/CustomControls/CustomControls/Views/CustomSliderView.swift
@@ -92,7 +92,7 @@ struct CustomSliderView<ThumbnailView: View>: UIViewRepresentable {
                 case .began,
                         .moved,
                         .ended:
-                    onTouchSliderEvent(touchEvent.location(in:  sender),
+                    onTouchSliderEvent(touchEvent.location(in: sender),
                                        sender.thumbFrame,
                                        sender.isTracking)
 

--- a/SwiftUI/CustomControls/CustomControls/Views/PlayerUIView.swift
+++ b/SwiftUI/CustomControls/CustomControls/Views/PlayerUIView.swift
@@ -51,7 +51,7 @@ struct PlayerUIView: View {
                             break
                         case .failure(let error):
                             showAlert.toggle()
-                            print("VideoModel - Error retrieving video: \(error.localizedDescription)")
+                            print("PlayerUIView - Error retrieving video: \(error.localizedDescription)")
                     }
                 }, receiveValue: { video in
                     guard let playbackController = playerModel.playbackController else { return }

--- a/SwiftUI/CustomControls/CustomControls/Views/VideoContainerView.swift
+++ b/SwiftUI/CustomControls/CustomControls/Views/VideoContainerView.swift
@@ -14,7 +14,7 @@ struct VideoContainerView: UIViewRepresentable {
     let view: UIView?
 
     func makeUIView(context: Context) -> UIView {
-        return view ?? UIView(frame: .zero)
+        view ?? UIView(frame: .zero)
     }
 
     func updateUIView(_ uiView: UIView, context: Context) {}

--- a/SwiftUI/SwiftUIPlayer/SwiftUIPlayer/Models/PlayerModel.swift
+++ b/SwiftUI/SwiftUIPlayer/SwiftUIPlayer/Models/PlayerModel.swift
@@ -1,6 +1,6 @@
 //
 //  PlayerModel.swift
-//  SwiftUICustomControls
+//  SwiftUIPlayer
 //
 //  Copyright © 2026 Brightcove, Inc. All rights reserved.
 //
@@ -44,10 +44,10 @@ final class PlayerModel: NSObject, ObservableObject {
         return playbackController
     }()
 
-    fileprivate(set) lazy var avpvc: AVPlayerViewController = {
-        let avpvc = AVPlayerViewController()
-        avpvc.delegate = self
-        return avpvc
+    fileprivate(set) lazy var avPlayerViewController: AVPlayerViewController = {
+        let avPlayerViewController = AVPlayerViewController()
+        avPlayerViewController.delegate = self
+        return avPlayerViewController
     }()
 
     fileprivate(set) lazy var bcovPlayerView: BCOVPUIPlayerView? = {
@@ -118,12 +118,10 @@ extension PlayerModel: BCOVPlaybackControllerDelegate {
            let options = controller.options,
            let useNative = options[kBCOVAVPlayerViewControllerCompatibilityKey] as? Bool,
            useNative {
-            avpvc.player = player
+            avPlayerViewController.player = player
         }
 
         currentVideoId = session?.video?.properties[BCOVVideo.PropertyKeyId] as? String
-
-        print("PlayerModel - Advanced to new session.")
     }
 
     func playbackController(_ controller: BCOVPlaybackController!,
@@ -137,7 +135,7 @@ extension PlayerModel: BCOVPlaybackControllerDelegate {
                             didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {
 
         if kBCOVPlaybackSessionLifecycleEventFail == lifecycleEvent.eventType,
-           let error = lifecycleEvent.properties["error"] as? NSError {
+           let error = lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError] as? NSError {
             // Report any errors that may have occurred with playback.
             print("PlayerModel - Playback error: \(error.localizedDescription)")
         }

--- a/SwiftUI/SwiftUIPlayer/SwiftUIPlayer/Models/PlaylistModel.swift
+++ b/SwiftUI/SwiftUIPlayer/SwiftUIPlayer/Models/PlaylistModel.swift
@@ -44,7 +44,7 @@ final class PlaylistModel: ObservableObject {
                 if let error {
                     print("PlaylistModel - Error retrieving video playlist: \(error.localizedDescription)")
                 }
-                
+
                 return
             }
 

--- a/SwiftUI/SwiftUIPlayer/SwiftUIPlayer/TimeInterval+Extensions.swift
+++ b/SwiftUI/SwiftUIPlayer/SwiftUIPlayer/TimeInterval+Extensions.swift
@@ -11,10 +11,10 @@ import Foundation
 extension TimeInterval {
 
     var stringFromTime: String {
-        if self.isFinite {
-            let hours = Int(self.truncatingRemainder(dividingBy: 86400) / 3600)
-            let minutes = Int(self.truncatingRemainder(dividingBy: 3600) / 60)
-            let seconds = Int(self.truncatingRemainder(dividingBy: 60))
+        if isFinite {
+            let hours = Int(truncatingRemainder(dividingBy: 86400) / 3600)
+            let minutes = Int(truncatingRemainder(dividingBy: 3600) / 60)
+            let seconds = Int(truncatingRemainder(dividingBy: 60))
             if hours > 0 {
                 return String(format: "%i:%02i:%02i", hours, minutes, seconds)
             } else {

--- a/SwiftUI/SwiftUIPlayer/SwiftUIPlayer/Views/ApplePlayerUIView.swift
+++ b/SwiftUI/SwiftUIPlayer/SwiftUIPlayer/Views/ApplePlayerUIView.swift
@@ -21,10 +21,10 @@ struct ApplePlayerUIView: UIViewControllerRepresentable {
             playbackController.options = [kBCOVAVPlayerViewControllerCompatibilityKey: true]
         }
 
-        return playerModel.avpvc
+        return playerModel.avPlayerViewController
     }
 
-    func updateUIViewController(_ avpvc: AVPlayerViewController, context: Context) {}
+    func updateUIViewController(_ avPlayerViewController: AVPlayerViewController, context: Context) {}
 
 }
 

--- a/SwiftUI/SwiftUIPlayer/SwiftUIPlayer/Views/ContentView.swift
+++ b/SwiftUI/SwiftUIPlayer/SwiftUIPlayer/Views/ContentView.swift
@@ -18,7 +18,6 @@ struct ContentView: View {
 
     enum Tab {
         case videos
-        case other
     }
 
     var body: some View {
@@ -28,12 +27,6 @@ struct ContentView: View {
                     Label("Videos", systemImage: "list.triangle")
                 }
                 .tag(Tab.videos)
-
-            Text("Hello, world!")
-                .tabItem {
-                    Label("Other", systemImage: "info")
-                }
-                .tag(Tab.other)
         }
     }
 }

--- a/SwiftUI/SwiftUIPlayer/SwiftUIPlayer/Views/ThumbnailView.swift
+++ b/SwiftUI/SwiftUIPlayer/SwiftUIPlayer/Views/ThumbnailView.swift
@@ -12,7 +12,7 @@ import BrightcovePlayerSDK
 struct ThumbnailView: View {
 
     @ObservedObject
-    var imageLoader:ImageLoader
+    var imageLoader: ImageLoader
 
     let urlStr: String?
 
@@ -25,7 +25,7 @@ struct ThumbnailView: View {
         Image(uiImage: UIImage(data: imageLoader.data) ?? UIImage())
             .resizable()
             .aspectRatio(contentMode: .fit)
-            .frame(width:50, height:50)
+            .frame(width: 50, height: 50)
     }
 }
 

--- a/SwiftUI/SwiftUIPlayer/SwiftUIPlayer/Views/ThumbnailView.swift
+++ b/SwiftUI/SwiftUIPlayer/SwiftUIPlayer/Views/ThumbnailView.swift
@@ -11,14 +11,14 @@ import BrightcovePlayerSDK
 
 struct ThumbnailView: View {
 
-    @ObservedObject
+    @StateObject
     var imageLoader: ImageLoader
 
     let urlStr: String?
 
     init(urlStr: String?) {
         self.urlStr = urlStr
-        imageLoader = ImageLoader(urlString: urlStr ?? "")
+        _imageLoader = StateObject(wrappedValue: ImageLoader(urlString: urlStr ?? ""))
     }
 
     var body: some View {

--- a/SwiftUI/SwiftUIPlayer/SwiftUIPlayer/Views/VideoListRowView.swift
+++ b/SwiftUI/SwiftUIPlayer/SwiftUIPlayer/Views/VideoListRowView.swift
@@ -12,15 +12,15 @@ import BrightcovePlayerSDK
 struct VideoListRowView: View {
 
     fileprivate var id: String? {
-        return video.properties[BCOVVideo.PropertyKeyId] as? String
+        video.properties[BCOVVideo.PropertyKeyId] as? String
     }
 
     fileprivate var name: String? {
-        return video.properties[BCOVVideo.PropertyKeyName] as? String
+        video.properties[BCOVVideo.PropertyKeyName] as? String
     }
 
     fileprivate var urlStr: String? {
-        return video.properties[BCOVVideo.PropertyKeyThumbnail] as? String
+        video.properties[BCOVVideo.PropertyKeyThumbnail] as? String
     }
 
     fileprivate var duration: String {

--- a/SwiftUI/SwiftUIPlayerIMA/SwiftUIPlayerIMA/Models/PlayerViewModel.swift
+++ b/SwiftUI/SwiftUIPlayerIMA/SwiftUIPlayerIMA/Models/PlayerViewModel.swift
@@ -177,11 +177,11 @@ extension PlayerViewModel: @preconcurrency BCOVPlaybackControllerDelegate {
             }
 
         case kBCOVIMALifecycleEventAdsLoaderFailed:
-            let description = (lifecycleEvent.properties["error"] as? NSError)?.localizedDescription ?? "unknown"
+            let description = (lifecycleEvent.properties[kBCOVIMALifecycleEventPropertyKeyAdError] as? IMAAdError)?.message ?? "unknown"
             Log.ads.error("IMA ads loader failed: \(description, privacy: .public)")
 
         case kBCOVIMALifecycleEventAdsManagerDidReceiveAdError:
-            let description = (lifecycleEvent.properties["error"] as? NSError)?.localizedDescription ?? "unknown"
+            let description = (lifecycleEvent.properties[kBCOVIMALifecycleEventPropertyKeyAdError] as? IMAAdError)?.message ?? "unknown"
             Log.ads.error("IMA ads manager error: \(description, privacy: .public)")
 
         case kBCOVIMALifecycleEventAdsLoaderLoaded:

--- a/SwiftUI/SwiftUIPlayerIMA/SwiftUIPlayerIMA/Models/PlayerViewModel.swift
+++ b/SwiftUI/SwiftUIPlayerIMA/SwiftUIPlayerIMA/Models/PlayerViewModel.swift
@@ -155,13 +155,13 @@ extension PlayerViewModel: @preconcurrency BCOVPlaybackControllerDelegate {
     }
 
     func playbackController(_ controller: BCOVPlaybackController!,
-                            playbackSession session: BCOVPlaybackSession,
+                            playbackSession session: BCOVPlaybackSession!,
                             didReceive lifecycleEvent: BCOVPlaybackSessionLifecycleEvent!) {
         let type = lifecycleEvent.eventType
 
         switch type {
         case kBCOVPlaybackSessionLifecycleEventFail:
-            if let error = lifecycleEvent.properties["error"] as? NSError {
+            if let error = lifecycleEvent.properties[kBCOVPlaybackSessionEventKeyError] as? NSError {
                 Log.playback.error("Playback failed: \(error.localizedDescription, privacy: .public)")
                 status = .failed(message: error.localizedDescription)
             }
@@ -192,7 +192,7 @@ extension PlayerViewModel: @preconcurrency BCOVPlaybackControllerDelegate {
             }
 
         case kBCOVIMALifecycleEventAdsManagerDidReceiveAdEvent:
-            if let adEvent = lifecycleEvent.properties["adEvent"] as? IMAAdEvent {
+            if let adEvent = lifecycleEvent.properties[kBCOVIMALifecycleEventPropertyKeyAdEvent] as? IMAAdEvent {
                 Log.ads.info("Ad event: \(adEvent.typeString, privacy: .public)")
             }
 


### PR DESCRIPTION
## What

A code-quality pass across the Swift sample apps: making them more idiomatic, consistent, correct, and better documented, without changing how any sample is configured.

### Cleanup & modernization (one commit per sample)
- Adopt current Swift idioms: `@main`, `guard let` shorthand, `[weak self]` in long-lived closures, dropping misused `lazy`, and clearer access control.
- Use the SDK's named constants instead of string-literal keys (e.g. `kBCOVPlaybackSessionEventKeyError`, `kBCOVIMALifecycleEventPropertyKeyAdError`, `kBCOVDAILifecycleEventPropertyKeyAdEvent`) so the samples read correctly and stay in step with the SDK.
- Remove dead and commented-out code and redundant logging.
- Add top-of-file summaries and DocC comments describing the key types in each sample.

### Bug fixes
A final commit resolves latent issues surfaced during the pass. These are the only changes that affect runtime behavior:

Crashes / safety
- DAI (iOS + tvOS): create the DAI session provider and access the player view only after unwrapping it, removing a force-unwrap crash path.
- Cast: read cast media metadata with safe optional casts instead of force casts.

Correctness
- Error and event handlers that read the wrong dictionary key or cast to the wrong type (so those events were silently never handled) now use the correct SDK keys and types.
- Subtitle rendering: fix WebVTT timestamp parsing that treated minutes as hours.
- SwiftUI: the thumbnail loader now completes on a network error instead of hanging, and the thumbnail view uses `@StateObject` so it is not recreated on re-render.
- VerticalPlayer: seed the pager from the correct video list.
- DAI: send the standard `tfcd` ad-tag parameter.
- PlayerUI control samples: smaller time-formatting and constraint-setup corrections.

Concurrency / lifecycle
- Offline: serialize access to the download queues to remove a data race, and update the downloads UI on the main thread.
- Now Playing: load remote-command-center artwork asynchronously and remove its command targets on `deinit`.
- SharePlay: surface GroupActivity activation failures through the delegate.

Config / docs
- Cast receiver: the splash screen no longer references an external image host; it is an optional, commented-out example, so the sample uses the default receiver splash and carries no third-party dependency.
- BasicCastPlayer: describe the included custom `GoogleCastManager` as a reference rather than a swap-in.

## Scope
- No renamed files, types, schemes, targets, or bundle identifiers, and no changes to any sample's account, policy key, or video IDs.
- The only behavioral changes are the bug fixes listed above.
- Every sample in this PR builds for its iOS/tvOS simulator destination.
- Ad-based samples (IMA, DAI) and Cast should be verified on a physical device, where their rendering is reliable.

## Not included
The Flutter and React Native samples are unchanged here; they will follow in a separate PR.
